### PR TITLE
Improve form layout system

### DIFF
--- a/docs/forms.md
+++ b/docs/forms.md
@@ -2,17 +2,19 @@
 
 Form pages are the work horses of the UI. This is where you view and edit the information for the work items the application handles, be they products, shops, market segments or anything else.
 
+To select the column layout, provide a `cols` attribute of an array of numbers. These numbers represent the width of their corresponding column, i.e. `[1,1,1]` represents three columns of the same width, while `[1,2]` represents two columns, the second one twice as wide as the first. The default value of `cols` is `[1,1,1]`. (If the legacy `wide` flag is used, any `cols`value will be overridden to `[1]` instead.) Form elements will be divided into columns evenly, so if you have five elements and three columns, the first column will contain elements 1 and 2, second column will have elements 3 and 4, while 5 will be in the last column.
+
 To provide the values entered into the form, a `value` prop should be provided (most likely from application state). An update function should be provided in the `getUpdater` prop that, given a field name, will return a function that will update that field wih the value passed as parameter (example: `fieldName => value => update(fieldName, value)`). This function can be memoized, which may help performance of large forms.
 
 The actual form fields and layout are defined by an array of data objects in the `fields` prop. The objects all hold at least a `type` string, which defines what further information it can use, and what it will be rendered as. See below for information on the different types of fields. Labels (in the `label` field) can be either plain strings or `react-intl` message descriptors.
 
 ## Structuring your form
 
-The `Fieldset` type provides a way to bundle together form elements, rendering them as a coherent field set with a title. The title is set in the `label` field of the data object, and the contained fields are given as an array of data objects in the `fields` field.
+The `Fieldset` type provides a way to bundle together form elements, rendering them as a coherent field set with a title. The title is set in the `label` field of the data object, and the contained fields are given as an array of data objects in the `fields` property.
 
 If there is a need for fields to be combined on a single line - for example inputting an amount and its currency in separate but connected controls - the `Combination` type provides a way to do so. It, like the field set, takes a list of field definitions, but will place them together on the same line.
 
-The relative amount of space given to each field can be set in the `proportions` field, which takes an array of either CSS size values (e.g. `'30px'`, `'12em'`, treated as rigid size definitions) or numbers (which are interpreted as percentages of full width, and can shrink to accommodate other fields).
+The relative amount of space given to each field can be set in the `proportions` property, which takes an array of either CSS size values (e.g. `'30px'`, `'12em'`, treated as rigid size definitions) or numbers (which are interpreted as percentages of full width, and can shrink to accommodate other fields).
 
 Combination fields can have a collective `label`, set on the combination itself, or labels on the component fields. An empty string as label will mean that space is set aside for the label without rendering one.
 
@@ -20,7 +22,7 @@ Combination fields can have a collective `label`, set on the combination itself,
 
 Two types of list are available, fixed and variable length, respectively. Both have the `List` type. Fixed length lists have a `rowCount` field and may have a `staticValues` field containing an array of data to be added to the corresponding row. Variable length lists will have a button to add rows, and each row a button to delete it. The add button should be labeled with the `add` field.
 
-In both cases, lists expect a single field definition object in the `rowField` field, but this may be a combination field. Any label given here will be used to build a list head, with each row being rendered as an unlabeled instance of the field definition.
+In both cases, lists expect a single field definition object in the `rowField` property, but this may be a combination field. Any label given here will be used to build a list head, with each row being rendered as an unlabeled instance of the field definition.
 
 Lists handle values presented as arrays of data objects, with fields in those data objects being mapped to named inputs in the row field. On changes (including addition and deletion of rows), they will call the update function with the entire list contents, updated according to which field was changed.
 
@@ -48,10 +50,10 @@ Translations to multiple languages can be handled with the `TranslationInput` ty
 
 ## On/off inputs
 
-Depending on the particlar purpose, binary values can be handled with either `CheckboxInput` or `SwitchInput`, both of which allow a value of true or false. The former shows a standard checkbox, useful where a compact or simple control is preferable, while the latter shows a more advanced switch toggle. The switch can be configured to change color and caption as required, using the `onColor`, `offColor`, `onCaption` and `offCaption` props (see also [the `<Switch>` component](components.md#switch)). The caption props can use plain strings, or message descriptors.
+Depending on the particular purpose, binary values can be handled with either `CheckboxInput` or `SwitchInput`, both of which allow a value of true or false. The former shows a standard checkbox, useful where a compact or simple control is preferable, while the latter shows a more advanced switch toggle. The switch can be configured to change color and caption as required, using the `onColor`, `offColor`, `onCaption` and `offCaption` props (see also [the `<Switch>` component](components.md#switch)). The caption props can use plain strings, or message descriptors.
 
 ## Miscellaneous
 
 Buttons with text and icons are available in the `Button` type. It follows the normal interface of the [`Button` component](components.md#Button), and uses the update function it is provided as a click handler. It may be provided with an `icon` and a `buttonText` (string or message descriptor).
 
-A variable length list shows a small button with an icon to delete rows from it, and for this it uses the `SmallButton` type. This control may also be used for other functions. The button must be provided with `icon` and an `altText` property describing the button function, to ensure accessibility.
+A variable length list shows a circular button with an icon to delete rows from it, and for this it uses the `SmallButton` type. This control may also be used for other functions. The button must be provided with `icon` and an `altText` property describing the button function, to ensure accessibility.

--- a/src/components/Form/FieldElements.js
+++ b/src/components/Form/FieldElements.js
@@ -11,7 +11,6 @@ const FieldElements = ({
 	labelOnly,
 	getUpdater = () => {},
 	values = {},
-	wide,
 	...elementProps
 }) => (
 	<React.Fragment>
@@ -23,7 +22,6 @@ const FieldElements = ({
 							<FieldElements
 								getUpdater={getUpdater}
 								values={values}
-								wide={wide}
 								{...elementProps}
 								{...props}
 							/>
@@ -41,7 +39,6 @@ const FieldElements = ({
 								getUpdater={getUpdater}
 								values={values}
 								labelOnly={labelOnly}
-								wide={wide}
 								{...elementProps}
 								{...props}
 							/>
@@ -57,7 +54,6 @@ const FieldElements = ({
 							values={values}
 							getUpdater={getUpdater}
 							rowCount={props.rowCount}
-							wide={wide}
 							{...elementProps}
 							{...props}
 						/>

--- a/src/components/Form/FieldList.js
+++ b/src/components/Form/FieldList.js
@@ -70,7 +70,7 @@ const decorateField = (field, remove = "[remove]") => {
 		type: "Combination",
 		name: "rowField",
 		// Set field base size to fit in field set
-		proportions: ["340px", "30px"],
+		proportions: [100, "30px"],
 		fields: [
 			field,
 			{

--- a/src/components/Form/FieldList.js
+++ b/src/components/Form/FieldList.js
@@ -91,7 +91,6 @@ export const FieldList = ({
 	rowField,
 	listUpdater,
 	rowCount,
-	wide,
 	listIndex,
 	...props
 }) => {

--- a/src/components/Form/FieldList.test.js
+++ b/src/components/Form/FieldList.test.js
@@ -185,7 +185,7 @@ describe("FieldList", () => {
 						{
 							type: "Combination",
 							name: "rowField",
-							proportions: ["340px", "30px"],
+							proportions: [100, "30px"],
 							fields: [
 								{ type: "TextInput", name: "data" },
 								{

--- a/src/components/Form/Form.js
+++ b/src/components/Form/Form.js
@@ -1,4 +1,5 @@
 import React from "react";
+import styled from "styled-components";
 import pt from "prop-types";
 import { memoize } from "../../utils";
 import routingConnector from "../../hocs/routingConnector";
@@ -6,105 +7,6 @@ import withScrollBox from "../../hocs/withScrollBox";
 import { cultureList } from "../../selectors/locale";
 import Form from "./FormElement";
 import FieldElements from "./FieldElements";
-
-const heights = {
-	label: 27,
-	baseInput: 30,
-	fieldMargin: 20,
-	listMargin: 10,
-	fieldsetHead: 47,
-};
-
-export const fieldHeight = (field, values = {}, numCultures = 1) => {
-	switch (field.type) {
-		case "Fieldset":
-			return (
-				heights.fieldsetHead +
-				heights.fieldMargin +
-				field.fields.reduce(
-					(sum, field) => sum + fieldHeight(field, values, numCultures),
-					0,
-				)
-			);
-		case "List": {
-			if (field.rowCount) {
-				return (
-					field.rowCount * (heights.baseInput + heights.listMargin) +
-					heights.listMargin +
-					heights.label
-				); // Assuming there is a label
-			} else {
-				return (
-					((values[field.name] || []).length + 1) *
-						(heights.baseInput + heights.listMargin) +
-					heights.listMargin +
-					heights.label
-				); // Assuming there is a label
-			}
-		}
-		case "Combination": {
-			let label = 0;
-			if (field.label !== undefined) {
-				label += heights.label;
-			}
-			if (field.fields.some(field => field.label !== undefined)) {
-				label += heights.label;
-			}
-			return heights.baseInput + heights.fieldMargin + label;
-		}
-		case "TranslationInput": {
-			// Set aside space enough to open fully
-			return (
-				numCultures * (heights.baseInput + heights.listMargin) +
-				heights.listMargin +
-				(field.label !== undefined ? heights.label : 0)
-			);
-		}
-		default:
-			return (
-				heights.baseInput +
-				heights.fieldMargin +
-				(field.label !== undefined ? heights.label : 0)
-			);
-	}
-};
-
-const colWidth = 480;
-export const calculateFormHeight = memoize(
-	(width, fields = [], values, numCultures) => {
-		const numColumns = Math.floor(width / colWidth);
-		const fieldHeights = fields.map(field =>
-			fieldHeight(field, values, numCultures),
-		);
-		const allFieldsHeight = fieldHeights.reduce((sum, h) => sum + h, 0);
-		const minColumnHeight = allFieldsHeight / numColumns - 50;
-		const columnHeights = fieldHeights.reduce(
-			(cols, height) => {
-				const [...outCols] = cols;
-				const lastIndex = outCols.length - 1;
-				if (height > minColumnHeight && outCols[lastIndex] !== 0) {
-					// Try to keep any very large elements alone
-					outCols.push(height);
-					/* istanbul ignore else */
-					if (outCols.length < numColumns) {
-						outCols.push(0);
-					}
-				} else {
-					outCols[lastIndex] += height;
-					if (
-						outCols[lastIndex] > minColumnHeight &&
-						outCols.length < numColumns
-					) {
-						outCols.push(0);
-					}
-				}
-				return outCols;
-			},
-			[0],
-		);
-		return Math.max(...columnHeights);
-	},
-);
 
 export const withCultureCount = routingConnector(
 	state => ({ cultureCount: cultureList(state).size }),
@@ -132,26 +34,52 @@ export const addNamesToFields = memoize(fields =>
 	}),
 );
 
+export const Wrapper = styled.div`
+	display: flex;
+`;
+
 export const FormPage = ({
+	cols = [1, 1, 1],
 	getUpdater,
 	fields,
 	values,
 	width = 1000,
 	cultureCount,
 	wide,
-}) => (
-	<Form
-		h={calculateFormHeight(width, fields, values, cultureCount)}
-		wide={wide}
-	>
-		<FieldElements
-			getUpdater={getUpdater}
-			fields={addNamesToFields(fields)}
-			values={values}
-			wide={wide}
-		/>
-	</Form>
-);
+}) => {
+	let colSpans = wide ? [1] : cols;
+	const colCount = colSpans.reduce((a, b) => a + b, 0);
+	const elmsPerCol = Math.ceil(fields.length / colSpans.length);
+	const colFields =
+		colSpans.length < 2
+			? [fields]
+			: fields.reduce((current, field, index) => {
+					if (index % elmsPerCol === 0) {
+						current.push([field]);
+					} else {
+						current[current.length - 1].push(field);
+					}
+					return current;
+			  }, []);
+	return (
+		<Wrapper>
+			{colFields.map((fields, index) => (
+				<Form
+					key={index}
+					spanWidth={colSpans[index] /* istanbul ignore next*/ || 1}
+					colCount={colCount}
+				>
+					<FieldElements
+						getUpdater={getUpdater}
+						fields={addNamesToFields(fields)}
+						values={values}
+						wide={wide}
+					/>
+				</Form>
+			))}
+		</Wrapper>
+	);
+};
 
 const WiredForm = withScrollBox(withCultureCount(FormPage));
 

--- a/src/components/Form/Form.js
+++ b/src/components/Form/Form.js
@@ -38,6 +38,19 @@ export const Wrapper = styled.div`
 	display: flex;
 `;
 
+const splitFields = (fields, cols) => {
+	if (cols <= 1) return [fields];
+	const elmsPerCol = Math.ceil(fields.length / cols);
+	return fields.reduce((current, field, index) => {
+		if (index % elmsPerCol === 0) {
+			current.push([field]);
+		} else {
+			current[current.length - 1].push(field);
+		}
+		return current;
+	}, []);
+};
+
 export const FormPage = ({
 	cols = [1, 1, 1],
 	getUpdater,
@@ -48,32 +61,18 @@ export const FormPage = ({
 	wide,
 }) => {
 	let colSpans = wide ? [1] : cols;
-	const colCount = colSpans.reduce((a, b) => a + b, 0);
-	const elmsPerCol = Math.ceil(fields.length / colSpans.length);
-	const colFields =
-		colSpans.length < 2
-			? [fields]
-			: fields.reduce((current, field, index) => {
-					if (index % elmsPerCol === 0) {
-						current.push([field]);
-					} else {
-						current[current.length - 1].push(field);
-					}
-					return current;
-			  }, []);
+	const colFields = splitFields(fields, colSpans.length);
 	return (
 		<Wrapper>
 			{colFields.map((fields, index) => (
 				<Form
 					key={index}
 					spanWidth={colSpans[index] /* istanbul ignore next*/ || 1}
-					colCount={colCount}
 				>
 					<FieldElements
 						getUpdater={getUpdater}
 						fields={addNamesToFields(fields)}
 						values={values}
-						wide={wide}
 					/>
 				</Form>
 			))}

--- a/src/components/Form/Form.test.js
+++ b/src/components/Form/Form.test.js
@@ -4,22 +4,28 @@ import { MemoryRouter } from "react-router-dom";
 import Immutable from "immutable";
 import Form from "./FormElement";
 import FieldElements from "./FieldElements";
-import {
-	fieldHeight,
-	calculateFormHeight,
-	withCultureCount,
-	addNamesToFields,
-	FormPage,
-} from "./Form";
+import { withCultureCount, addNamesToFields, FormPage, Wrapper } from "./Form";
 
 describe("FormPage", () => {
-	let getUpdater, fields;
+	let getUpdater, fields, manyFields;
 	beforeEach(() => {
 		getUpdater = () => {};
 		fields = [{ type: "TextInput", name: "text1", label: "A text" }];
+		manyFields = [
+			{ type: "TextInput", name: "text0", label: "A text" },
+			{ type: "TextInput", name: "text1", label: "A text" },
+			{ type: "TextInput", name: "text2", label: "A text" },
+			{ type: "TextInput", name: "text3", label: "A text" },
+			{ type: "TextInput", name: "text4", label: "A text" },
+			{ type: "TextInput", name: "text5", label: "A text" },
+			{ type: "TextInput", name: "text6", label: "A text" },
+			{ type: "TextInput", name: "text7", label: "A text" },
+			{ type: "TextInput", name: "text8", label: "A text" },
+			{ type: "TextInput", name: "text9", label: "A text" },
+		];
 	});
 
-	it("renders a form and calculates a best-guess height", () =>
+	it("renders a form with a single field", () =>
 		expect(
 			<FormPage
 				fields={fields}
@@ -27,348 +33,63 @@ describe("FormPage", () => {
 				getUpdater={getUpdater}
 			/>,
 			"to render as",
-			<Form h={77} wide={undefined}>
-				<FieldElements
-					getUpdater={getUpdater}
-					fields={fields}
-					values={{ text1: "foo" }}
-				/>
-			</Form>,
+			<Wrapper>
+				<Form spanWidth={1} colCount={3}>
+					<FieldElements
+						getUpdater={getUpdater}
+						fields={fields}
+						values={{ text1: "foo" }}
+					/>
+				</Form>
+			</Wrapper>,
 		));
-});
 
-describe("fieldHeight", () => {
-	it("calculates the height of a single field", () =>
+	it("still respects 'wide' flag", () =>
 		expect(
-			fieldHeight,
-			"called with",
-			[{ type: "TextInput", name: "text1" }, { text1: "foo" }],
-			"to equal",
-			30 + 20,
+			<FormPage
+				wide
+				fields={fields}
+				values={{ text1: "foo" }}
+				getUpdater={getUpdater}
+			/>,
+			"to render as",
+			<Wrapper>
+				<Form spanWidth={1} colCount={1}>
+					<FieldElements
+						getUpdater={getUpdater}
+						fields={fields}
+						values={{ text1: "foo" }}
+					/>
+				</Form>
+			</Wrapper>,
 		));
 
-	it("calculates the height of a single field with label", () =>
+	it("renders a form with a multiple fields", () =>
 		expect(
-			fieldHeight,
-			"called with",
-			[{ type: "TextInput", name: "text1", label: "A text" }, { text1: "foo" }],
-			"to equal",
-			27 + 30 + 20,
+			<FormPage
+				cols={[2, 1]}
+				fields={manyFields}
+				values={{ text1: "foo" }}
+				getUpdater={getUpdater}
+			/>,
+			"to render as",
+			<Wrapper>
+				<Form spanWidth={2} colCount={3}>
+					<FieldElements
+						getUpdater={getUpdater}
+						fields={manyFields.slice(0, 5)}
+						values={{ text1: "foo" }}
+					/>
+				</Form>
+				<Form spanWidth={1} colCount={3}>
+					<FieldElements
+						getUpdater={getUpdater}
+						fields={manyFields.slice(5, 10)}
+						values={{ text1: "foo" }}
+					/>
+				</Form>
+			</Wrapper>,
 		));
-
-	it("calculates the height of a field set", () =>
-		expect(
-			fieldHeight,
-			"called with",
-			[
-				{
-					type: "Fieldset",
-					name: "set",
-					label: "A text",
-					fields: [
-						{
-							type: "TextInput",
-							name: "var1",
-							label: "A text",
-						},
-						{ type: "NumberInput", name: "var2", label: "A number" },
-					],
-				},
-				{ var1: "foo", var2: 5 },
-			],
-			"to equal",
-			47 + 77 + 77 + 20,
-		));
-
-	it("calculates the height of a combination field with outer label", () =>
-		expect(
-			fieldHeight,
-			"called with",
-			[
-				{
-					type: "Combination",
-					name: "combo",
-					label: "A text",
-					proportions: [60, 40],
-					fields: [
-						{ type: "TextInput", name: "var1" },
-						{ type: "NumberInput", name: "var2" },
-					],
-				},
-				{ var1: "foo", var2: 5 },
-			],
-			"to equal",
-			27 + 30 + 20,
-		));
-
-	it("calculates the height of a combination field with inner labels", () =>
-		expect(
-			fieldHeight,
-			"called with",
-			[
-				{
-					type: "Combination",
-					name: "combo",
-					proportions: [60, 40],
-					fields: [
-						{
-							type: "TextInput",
-							name: "var1",
-							label: "A text",
-						},
-						{
-							type: "NumberInput",
-							name: "var2",
-							label: "A number",
-						},
-					],
-				},
-				{ var1: "foo", var2: 5 },
-			],
-			"to equal",
-			27 + 30 + 20,
-		));
-
-	it("calculates the height of a variable length list", () =>
-		expect(
-			fieldHeight,
-			"called with",
-			[
-				{
-					type: "List",
-					name: "list",
-					rowField: {
-						type: "TextInput",
-						name: "var1",
-						label: "A text",
-					},
-				},
-				{ list: [{ var1: "foo" }, { var1: "bar" }, { var1: "meep" }] },
-			],
-			"to equal",
-			27 + 3 * 40 + 40 + 10,
-		));
-
-	it("calculates the height of an empty variable length list", () =>
-		expect(
-			fieldHeight,
-			"called with",
-			[
-				{
-					type: "List",
-					name: "list",
-					rowField: {
-						type: "TextInput",
-						name: "var1",
-						label: "A text",
-					},
-				},
-			],
-			"to equal",
-			27 + 0 * 40 + 40 + 10,
-		));
-
-	it("calculates the height of a fixed length list", () =>
-		expect(
-			fieldHeight,
-			"called with",
-			[
-				{
-					type: "List",
-					name: "list",
-					rowCount: 3,
-					rowField: {
-						type: "TextInput",
-						name: "var1",
-						label: "A text",
-					},
-				},
-				{ list: [{ var1: "foo" }, { var1: "bar" }, { var1: "meep" }] },
-			],
-			"to equal",
-			27 + 3 * 40 + 10,
-		));
-
-	it("calculates the height of a translation input with label", () =>
-		expect(
-			fieldHeight,
-			"called with",
-			[
-				{
-					type: "TranslationInput",
-					name: "translate",
-					label: "Translated text",
-				},
-				{},
-				4,
-			],
-			"to equal",
-			27 + 4 * 40 + 10,
-		));
-
-	it("calculates the height of a translation input without label", () =>
-		expect(
-			fieldHeight,
-			"called with",
-			[
-				{
-					type: "TranslationInput",
-					name: "translate",
-				},
-				{},
-				4,
-			],
-			"to equal",
-			4 * 40 + 10,
-		));
-});
-
-describe("calculateFormHeight", () => {
-	it("determines the height a form needs to house its elements", () =>
-		expect(
-			calculateFormHeight,
-			"called with",
-			[
-				1500,
-				[
-					{ type: "TextInput", name: "text1", label: "A text" },
-					{
-						type: "Fieldset",
-						name: "set",
-						label: "A text",
-						fields: [
-							{
-								type: "TextInput",
-								name: "var1",
-								label: "A text",
-							},
-							{ type: "NumberInput", name: "var2", label: "A number" },
-						],
-					},
-					{ type: "TextInput", name: "text2", label: "A different text" },
-				],
-			],
-			"to equal",
-			fieldHeight({
-				type: "Fieldset",
-				name: "set",
-				label: "A text",
-				fields: [
-					{
-						type: "TextInput",
-						name: "var1",
-						label: "A text",
-					},
-					{ type: "NumberInput", name: "var2", label: "A number" },
-				],
-			}),
-		));
-
-	it("stays within width bounds where possible", () =>
-		expect(
-			calculateFormHeight,
-			"called with",
-			[
-				500,
-				[
-					{ type: "TextInput", name: "text1", label: "A text" },
-					{
-						type: "Fieldset",
-						name: "set",
-						label: "A text",
-						fields: [
-							{
-								type: "TextInput",
-								name: "var1",
-								label: "A text",
-							},
-							{ type: "NumberInput", name: "var2", label: "A number" },
-						],
-					},
-				],
-			],
-			"to equal",
-			fieldHeight({ type: "TextInput", name: "text1", label: "A text" }) +
-				fieldHeight({
-					type: "Fieldset",
-					name: "set",
-					label: "A text",
-					fields: [
-						{
-							type: "TextInput",
-							name: "var1",
-							label: "A text",
-						},
-						{ type: "NumberInput", name: "var2", label: "A number" },
-					],
-				}),
-		));
-
-	it("tries to set very large elements alone", () =>
-		expect(
-			calculateFormHeight,
-			"called with",
-			[
-				2000,
-				[
-					{ type: "TextInput", name: "text1", label: "A text" },
-					{ type: "TextInput", name: "text2", label: "A text" },
-					{ type: "TextInput", name: "text3", label: "A text" },
-					{ type: "TextInput", name: "text4", label: "A text" },
-					{ type: "TextInput", name: "text5", label: "A text" },
-					{
-						type: "Fieldset",
-						name: "set",
-						label: "A text",
-						fields: [
-							{
-								type: "List",
-								name: "list",
-								rowCount: 6,
-								rowField: {
-									type: "TextInput",
-									name: "var1",
-									label: "A text",
-								},
-							},
-							{
-								type: "TextInput",
-								name: "var1",
-								label: "A text",
-							},
-							{ type: "NumberInput", name: "var2", label: "A number" },
-						],
-					},
-				],
-			],
-			"to equal",
-			fieldHeight({
-				type: "Fieldset",
-				name: "set",
-				label: "A text",
-				fields: [
-					{
-						type: "List",
-						name: "list",
-						rowCount: 6,
-						rowField: {
-							type: "TextInput",
-							name: "var1",
-							label: "A text",
-						},
-					},
-					{
-						type: "TextInput",
-						name: "var1",
-						label: "A text",
-					},
-					{ type: "NumberInput", name: "var2", label: "A number" },
-				],
-			}),
-		));
-
-	it("does not break if fields undefined", () =>
-		expect(calculateFormHeight, "called with", [1000], "to equal", 0));
 });
 
 const TestComp = () => <div />;

--- a/src/components/Form/Form.test.js
+++ b/src/components/Form/Form.test.js
@@ -34,7 +34,7 @@ describe("FormPage", () => {
 			/>,
 			"to render as",
 			<Wrapper>
-				<Form spanWidth={1} colCount={3}>
+				<Form spanWidth={1}>
 					<FieldElements
 						getUpdater={getUpdater}
 						fields={fields}
@@ -54,7 +54,7 @@ describe("FormPage", () => {
 			/>,
 			"to render as",
 			<Wrapper>
-				<Form spanWidth={1} colCount={1}>
+				<Form spanWidth={1}>
 					<FieldElements
 						getUpdater={getUpdater}
 						fields={fields}
@@ -74,14 +74,14 @@ describe("FormPage", () => {
 			/>,
 			"to render as",
 			<Wrapper>
-				<Form spanWidth={2} colCount={3}>
+				<Form spanWidth={2}>
 					<FieldElements
 						getUpdater={getUpdater}
 						fields={manyFields.slice(0, 5)}
 						values={{ text1: "foo" }}
 					/>
 				</Form>
-				<Form spanWidth={1} colCount={3}>
+				<Form spanWidth={1}>
 					<FieldElements
 						getUpdater={getUpdater}
 						fields={manyFields.slice(5, 10)}

--- a/src/components/Form/FormElement.js
+++ b/src/components/Form/FormElement.js
@@ -2,14 +2,13 @@ import styled from "styled-components";
 
 const Form = styled.div`
 	box-sizing: border-box;
-	flex-basis: calc(
-		100% * ${({ colCount = 1, spanWidth = 1 }) => spanWidth / colCount}
-	);
+	flex-basis: 0;
 	flex-shrink: 0;
-	flex-grow: 0;
+	flex-grow: ${({ spanWidth = 1 }) => spanWidth};
 	display: flex;
 	flex-direction: column;
-	padding: 50px;
+	padding: 0;
+	padding-right: 20px;
 	padding-top: 0;
 	font-size: 12px;
 

--- a/src/components/Form/FormElement.js
+++ b/src/components/Form/FormElement.js
@@ -1,33 +1,21 @@
-import styled, { css } from "styled-components";
-import { ifFlag } from "../../utils";
-import { SelectedValue } from "../Selector";
+import styled from "styled-components";
+
 const Form = styled.div`
-	flex: 1 0 auto;
+	box-sizing: border-box;
+	flex-basis: calc(
+		100% * ${({ colCount = 1, spanWidth = 1 }) => spanWidth / colCount}
+	);
+	flex-shrink: 0;
+	flex-grow: 0;
 	display: flex;
 	flex-direction: column;
-	padding: 20px;
+	padding: 50px;
 	padding-top: 0;
 	font-size: 12px;
 
-	${ifFlag(
-		"wide",
-		css`
-			& ${SelectedValue} {
-				width: calc(100vw - 200px);
-				${"" /* XXX: This works for base cases, needs to be better - Gert */}
-			}
-		`,
-		css`
-			flex-wrap: wrap;
-			align-items: flex-start;
-			align-content: flex-start;
-			height: ${props => props.h + 20 || 1000}px;
-			& > * {
-				margin-right: 50px;
-				width: 430px;
-			}
-		`,
-	)};
+	&:first-child {
+		padding-left: 20px;
+	}
 `;
 
 export default Form;

--- a/src/components/Form/FormElement.test.js
+++ b/src/components/Form/FormElement.test.js
@@ -2,27 +2,19 @@ import React from "react";
 import Form from "./FormElement";
 
 describe("Form wrapper", () => {
-	it("wraps children around", () =>
+	it("sets column width based on span and full width", () =>
+		expect(
+			<Form spanWidth={2} colCount={4} />,
+			"to render style rules",
+			"to contain",
+			"flex-basis: calc( 100% * 0.5 )",
+		));
+
+	it("sets default column width", () =>
 		expect(
 			<Form />,
 			"to render style rules",
 			"to contain",
-			"flex-wrap: wrap;",
-		));
-
-	it("sets height according to parameter", () =>
-		expect(
-			<Form h={325} />,
-			"to render style rules",
-			"to contain",
-			"height: 345px;",
-		));
-
-	it("does not wrap or set height when flagged as wide", () =>
-		expect(<Form wide />, "to render style rules").then(styles =>
-			expect(styles, "not to contain", "flex-wrap").and(
-				"not to contain",
-				"height",
-			),
+			"flex-basis: calc( 100% * 1 )",
 		));
 });

--- a/src/components/Form/FormElement.test.js
+++ b/src/components/Form/FormElement.test.js
@@ -2,19 +2,14 @@ import React from "react";
 import Form from "./FormElement";
 
 describe("Form wrapper", () => {
-	it("sets column width based on span and full width", () =>
+	it("sets column width based on given span width", () =>
 		expect(
-			<Form spanWidth={2} colCount={4} />,
+			<Form spanWidth={2} />,
 			"to render style rules",
 			"to contain",
-			"flex-basis: calc( 100% * 0.5 )",
+			"flex-grow: 2",
 		));
 
 	it("sets default column width", () =>
-		expect(
-			<Form />,
-			"to render style rules",
-			"to contain",
-			"flex-basis: calc( 100% * 1 )",
-		));
+		expect(<Form />, "to render style rules", "to contain", "flex-grow: 1"));
 });


### PR DESCRIPTION
Simplified and improved form column layout. Default (3 columns, equal width) and `wide` flag (single full-width column) still work reasonably close to before.
