### PR TITLE
The current scope was not always visible when opening the selector.

### DIFF
--- a/src/components/Scope/Scope.test.js
+++ b/src/components/Scope/Scope.test.js
@@ -49,6 +49,7 @@ beforeEach(() => {
 				name: { "en-CA": "Test 3" },
 				foo: true,
 				bar: false,
+				parentScopeId: "test1",
 			},
 			test4: {
 				id: "test4",
@@ -146,6 +147,18 @@ describe("Scope", () => {
 				args: [
 					{
 						type: "VIEW_STATE_SET_FIELD",
+						payload: {
+							name: "scopeSelector",
+							field: "nodeState",
+							value: { foo: true, bar: false },
+						},
+					},
+				],
+			},
+			{
+				args: [
+					{
+						type: "VIEW_STATE_SET_FIELD",
 						payload: { name: "scopeSelector", field: "filter", value: "text" },
 					},
 				],
@@ -155,6 +168,54 @@ describe("Scope", () => {
 					{
 						type: VIEW_SET_FIELD,
 						payload: { name: "scopeSelector", field: "show", value: false },
+					},
+				],
+			},
+		]);
+	});
+
+	it("renders with appropriate node state including default node state", () => {
+		state = state.setIn(["view", "scopeSelector", "filter"], "");
+		state = state.setIn(["navigation", "route", "match", "params", "scope"], "test3");
+
+		ReactDOM.render(
+			<div>
+				<Provider store={store}>
+					<IntlProvider locale="en">
+						<MemoryRouter>
+							<Scope
+								filterPlaceholder={{
+									defaultMessage: "Type a scope name",
+									id: "test.placeholder",
+								}}
+							></Scope>
+						</MemoryRouter>
+					</IntlProvider>
+				</Provider>
+			</div>,
+			appRoot,
+		);
+
+		simulate(appRoot, { type: "click", target: "." + getClassName(<AlignedButton />) });
+
+		expect(store.dispatch, "to have calls satisfying", [
+			{
+				args: [
+					{
+						type: "VIEW_STATE_SET_FIELD",
+						payload: {
+							name: "scopeSelector",
+							field: "nodeState",
+							value: { foo: true, bar: false, test1: true },
+						},
+					},
+				],
+			},
+			{
+				args: [
+					{
+						type: VIEW_SET_FIELD,
+						payload: { name: "scopeSelector", field: "show", value: true },
 					},
 				],
 			},
@@ -205,9 +266,7 @@ describe("ScopeBar", () => {
 			</Bar>,
 		).then(() =>
 			Promise.all([
-				expect(updateViewState, "to have calls satisfying", [
-					{ args: ["show", true] },
-				]),
+				expect(updateViewState, "to have calls satisfying", [{ args: ["show", true] }]),
 			]),
 		));
 });
@@ -231,11 +290,7 @@ describe("RoutedScope", () => {
 			</Provider>,
 			appRoot,
 		);
-		return expect(
-			appRoot,
-			"to contain",
-			<PropStruct pathname="/test1/foo" itIs="me" />,
-		);
+		return expect(appRoot, "to contain", <PropStruct pathname="/test1/foo" itIs="me" />);
 	});
 
 	it("redirects to Global if route not matched", () => {
@@ -251,10 +306,6 @@ describe("RoutedScope", () => {
 			</Provider>,
 			appRoot,
 		);
-		return expect(
-			appRoot,
-			"to contain",
-			<PropStruct pathname="/Global" itIs="me" />,
-		);
+		return expect(appRoot, "to contain", <PropStruct pathname="/Global" itIs="me" />);
 	});
 });

--- a/src/components/Scope/Scope.test.js
+++ b/src/components/Scope/Scope.test.js
@@ -147,18 +147,6 @@ describe("Scope", () => {
 				args: [
 					{
 						type: "VIEW_STATE_SET_FIELD",
-						payload: {
-							name: "scopeSelector",
-							field: "nodeState",
-							value: { foo: true, bar: false },
-						},
-					},
-				],
-			},
-			{
-				args: [
-					{
-						type: "VIEW_STATE_SET_FIELD",
 						payload: { name: "scopeSelector", field: "filter", value: "text" },
 					},
 				],
@@ -168,54 +156,6 @@ describe("Scope", () => {
 					{
 						type: VIEW_SET_FIELD,
 						payload: { name: "scopeSelector", field: "show", value: false },
-					},
-				],
-			},
-		]);
-	});
-
-	it("renders with appropriate node state including default node state", () => {
-		state = state.setIn(["view", "scopeSelector", "filter"], "");
-		state = state.setIn(["navigation", "route", "match", "params", "scope"], "test3");
-
-		ReactDOM.render(
-			<div>
-				<Provider store={store}>
-					<IntlProvider locale="en">
-						<MemoryRouter>
-							<Scope
-								filterPlaceholder={{
-									defaultMessage: "Type a scope name",
-									id: "test.placeholder",
-								}}
-							></Scope>
-						</MemoryRouter>
-					</IntlProvider>
-				</Provider>
-			</div>,
-			appRoot,
-		);
-
-		simulate(appRoot, { type: "click", target: "." + getClassName(<AlignedButton />) });
-
-		expect(store.dispatch, "to have calls satisfying", [
-			{
-				args: [
-					{
-						type: "VIEW_STATE_SET_FIELD",
-						payload: {
-							name: "scopeSelector",
-							field: "nodeState",
-							value: { foo: true, bar: false, test1: true },
-						},
-					},
-				],
-			},
-			{
-				args: [
-					{
-						type: VIEW_SET_FIELD,
-						payload: { name: "scopeSelector", field: "show", value: true },
 					},
 				],
 			},

--- a/src/components/Scope/index.js
+++ b/src/components/Scope/index.js
@@ -6,6 +6,7 @@ import useViewState from "../../hooks/useViewState";
 import useScopeData from "./useScopeData";
 import Button from "../Button";
 import Selector from "./Selector";
+import usePreviousModified from "../../hooks/usePreviousModified";
 
 export const Bar = styled.div`
 	flex: 0 0 49px;
@@ -41,6 +42,11 @@ export const Scope = ({ children, filterPlaceholder }) => {
 	const name = "scopeSelector";
 	const [currentScope, defaultNodeState, getScope] = useScopeData();
 	const [{ show = false, nodeState, filter }, updateViewState] = useViewState(name);
+	const opening = usePreviousModified(
+		show,
+		(prevShow, currentShow) => prevShow === false && currentShow === true,
+	);
+
 	const reset = event => {
 		updateViewState("show", false);
 		event.stopPropagation();
@@ -61,7 +67,7 @@ export const Scope = ({ children, filterPlaceholder }) => {
 				reset={reset}
 				getScope={getScope}
 				nodeState={nodeState}
-				defaultNodeState={defaultNodeState}
+				defaultNodeState={opening ? defaultNodeState : {}}
 				filter={filter}
 				updateFilter={updateFilter}
 				filterPlaceholder={filterPlaceholder}

--- a/src/components/Scope/index.js
+++ b/src/components/Scope/index.js
@@ -42,9 +42,10 @@ export const Scope = ({ children, filterPlaceholder }) => {
 	const name = "scopeSelector";
 	const [currentScope, defaultNodeState, getScope] = useScopeData();
 	const [{ show = false, nodeState, filter }, updateViewState] = useViewState(name);
-	const opening = usePreviousModified(
+	usePreviousModified(
 		show,
-		(prevShow, currentShow) => prevShow === false && currentShow === true,
+		current =>
+			current && updateViewState("nodeState", { ...nodeState, ...defaultNodeState }),
 	);
 
 	const reset = event => {
@@ -52,6 +53,7 @@ export const Scope = ({ children, filterPlaceholder }) => {
 		event.stopPropagation();
 	};
 	const updateFilter = event => updateViewState("filter", event.target.value);
+
 	return (
 		<React.Fragment>
 			<ScopeBar
@@ -66,8 +68,6 @@ export const Scope = ({ children, filterPlaceholder }) => {
 				show={show}
 				reset={reset}
 				getScope={getScope}
-				nodeState={nodeState}
-				defaultNodeState={opening ? defaultNodeState : {}}
 				filter={filter}
 				updateFilter={updateFilter}
 				filterPlaceholder={filterPlaceholder}

--- a/src/components/Scope/index.js
+++ b/src/components/Scope/index.js
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect } from "react";
 import styled from "styled-components";
 import { Route, Switch, Redirect } from "react-router-dom";
 import { getThemeProp } from "../../utils";
@@ -42,6 +42,7 @@ export const Scope = ({ children, filterPlaceholder }) => {
 	const name = "scopeSelector";
 	const [currentScope, defaultNodeState, getScope] = useScopeData();
 	const [{ show = false, nodeState, filter }, updateViewState] = useViewState(name);
+
 	usePreviousModified(
 		show,
 		current =>
@@ -70,6 +71,7 @@ export const Scope = ({ children, filterPlaceholder }) => {
 				getScope={getScope}
 				filter={filter}
 				updateFilter={updateFilter}
+				defaultNodeState={{}}
 				filterPlaceholder={filterPlaceholder}
 			/>
 			{children}

--- a/src/components/Treeview/Treeview.test.js
+++ b/src/components/Treeview/Treeview.test.js
@@ -233,7 +233,7 @@ describe("TreeView", () => {
 		);
 	});
 
-	it("overrides default node state with view state", () => {
+	it("overrides view state with default node state", () => {
 		state = state.setIn(["view", "testTree", "nodeState", "testNode1"], false);
 		return expect(
 			<Provider store={store}>
@@ -252,11 +252,26 @@ describe("TreeView", () => {
 				<Branch>
 					<Leaf>
 						<BeforeIndicator />
-						<Indicator />
+						<Indicator open />
 						<Label>
 							<div id="testNode1" />
 						</Label>
 					</Leaf>
+					<Branch>
+						<Leaf>
+							<BeforeIndicator />
+							<Indicator />
+							<Label>
+								<div id="testNode3" />
+							</Label>
+						</Leaf>
+						<Leaf>
+							<NonIndicator />
+							<Label>
+								<div id="testNode4" />
+							</Label>
+						</Leaf>
+					</Branch>
 					<Leaf>
 						<NonIndicator />
 						<Label>
@@ -392,11 +407,7 @@ describe("TreeView", () => {
 		expect(
 			<Provider store={store}>
 				<MemoryRouter>
-					<Treeview
-						{...testProps}
-						openAll
-						data-test-info="A test data variable"
-					/>
+					<Treeview {...testProps} openAll data-test-info="A test data variable" />
 				</MemoryRouter>
 			</Provider>,
 			"when mounted",

--- a/src/components/Treeview/Treeview.test.js
+++ b/src/components/Treeview/Treeview.test.js
@@ -233,7 +233,7 @@ describe("TreeView", () => {
 		);
 	});
 
-	it("overrides view state with default node state", () => {
+	it("overrides default node state with view state", () => {
 		state = state.setIn(["view", "testTree", "nodeState", "testNode1"], false);
 		return expect(
 			<Provider store={store}>
@@ -252,26 +252,11 @@ describe("TreeView", () => {
 				<Branch>
 					<Leaf>
 						<BeforeIndicator />
-						<Indicator open />
+						<Indicator />
 						<Label>
 							<div id="testNode1" />
 						</Label>
 					</Leaf>
-					<Branch>
-						<Leaf>
-							<BeforeIndicator />
-							<Indicator />
-							<Label>
-								<div id="testNode3" />
-							</Label>
-						</Leaf>
-						<Leaf>
-							<NonIndicator />
-							<Label>
-								<div id="testNode4" />
-							</Label>
-						</Leaf>
-					</Branch>
 					<Leaf>
 						<NonIndicator />
 						<Label>

--- a/src/components/Treeview/index.js
+++ b/src/components/Treeview/index.js
@@ -20,7 +20,7 @@ export const Treeview = ({
 	...otherProps
 }) => {
 	const [viewState, updateViewState] = useViewState(name);
-	const nodeState = { ...defaultNodeState, ...viewState.nodeState };
+	const nodeState = { ...viewState.nodeState, ...defaultNodeState };
 	const updateNodeState = update => updateViewState("nodeState", update);
 	return (
 		<Wrapper>

--- a/src/components/Treeview/index.js
+++ b/src/components/Treeview/index.js
@@ -20,7 +20,7 @@ export const Treeview = ({
 	...otherProps
 }) => {
 	const [viewState, updateViewState] = useViewState(name);
-	const nodeState = { ...viewState.nodeState, ...defaultNodeState };
+	const nodeState = { ...defaultNodeState, ...viewState.nodeState };
 	const updateNodeState = update => updateViewState("nodeState", update);
 	return (
 		<Wrapper>

--- a/src/hooks/usePreviousModified.js
+++ b/src/hooks/usePreviousModified.js
@@ -1,0 +1,15 @@
+import { useEffect, useRef } from "react";
+
+const usePreviousModified = (value, predicate) => {
+	const ref = useRef();
+
+	useEffect(() => {
+		ref.current = value;
+	}, [value]);
+
+	return predicate
+		? predicate(ref.current, value)
+		: ref.current !== undefined && ref.current !== null && ref.current !== value;
+};
+
+export default usePreviousModified;

--- a/src/hooks/usePreviousModified.js
+++ b/src/hooks/usePreviousModified.js
@@ -9,17 +9,19 @@ const usePreviousModified = (
 	effectAction = null,
 	predicate = defaultPredicate,
 ) => {
-	const ref = useRef();
+	const ref = useRef(value);
+
+	const predicateResult = predicate(ref.current, value);
 
 	useEffect(() => {
-		if (effectAction != null && predicate(ref.current, value)) {
-			effectAction(value);
+		if (effectAction != null && predicateResult) {
+			effectAction(value, ref.current);
 		}
 
 		ref.current = value;
 	}, [value]);
 
-	return predicate(ref.current, value);
+	return predicateResult;
 };
 
 export default usePreviousModified;

--- a/src/hooks/usePreviousModified.js
+++ b/src/hooks/usePreviousModified.js
@@ -12,7 +12,9 @@ const usePreviousModified = (
 	const ref = useRef();
 
 	useEffect(() => {
-		if (effectAction != null) effectAction(value);
+		if (effectAction != null && predicate(ref.current, value)) {
+			effectAction(value);
+		}
 
 		ref.current = value;
 	}, [value]);

--- a/src/hooks/usePreviousModified.js
+++ b/src/hooks/usePreviousModified.js
@@ -1,15 +1,23 @@
 import { useEffect, useRef } from "react";
 
-const usePreviousModified = (value, predicate) => {
+const defaultPredicate = (previous, current) => {
+	return previous !== undefined && previous !== null && previous !== current;
+};
+
+const usePreviousModified = (
+	value,
+	effectAction = null,
+	predicate = defaultPredicate,
+) => {
 	const ref = useRef();
 
 	useEffect(() => {
+		if (effectAction != null) effectAction(value);
+
 		ref.current = value;
 	}, [value]);
 
-	return predicate
-		? predicate(ref.current, value)
-		: ref.current !== undefined && ref.current !== null && ref.current !== value;
+	return predicate(ref.current, value);
 };
 
 export default usePreviousModified;

--- a/src/hooks/usePreviousModified.test.js
+++ b/src/hooks/usePreviousModified.test.js
@@ -86,7 +86,7 @@ describe("usePreviousModified", () => {
 		);
 	});
 
-	it("execute effect action when defined", () => {
+	it("execute effect action when defined and predicate satisfied", () => {
 		let actionValue = "before";
 
 		const effectAction = () => (actionValue = "after");
@@ -105,5 +105,33 @@ describe("usePreviousModified", () => {
 		);
 
 		expect(actionValue, "to equal", "after");
+	});
+
+	it("do not execute effect action when defined and predicate not satisfied", () => {
+		const predicate = (p, c) => c >= 15;
+
+		let actionValue = "before";
+
+		const effectAction = () => (actionValue = "after");
+
+		expect(
+			<Provider store={store}>
+				<MemoryRouter>
+					<TestComp
+						initCount={10}
+						value={14}
+						effectAction={effectAction}
+						predicate={predicate}
+					/>
+				</MemoryRouter>
+			</Provider>,
+			"when mounted",
+			"with event",
+			"click",
+			"to satisfy",
+			<div>false</div>,
+		);
+
+		expect(actionValue, "to equal", "before");
 	});
 });

--- a/src/hooks/usePreviousModified.test.js
+++ b/src/hooks/usePreviousModified.test.js
@@ -6,9 +6,9 @@ import sinon from "sinon";
 import usePreviousModified from "./usePreviousModified";
 import { useState } from "react";
 
-const TestComp = ({ initCount, value, predicate }) => {
+const TestComp = ({ initCount, value, effectAction, predicate }) => {
 	const [count, setCount] = useState(initCount);
-	const modified = usePreviousModified(count, predicate);
+	const modified = usePreviousModified(count, effectAction, predicate);
 
 	return <div onClick={() => setCount(value)}>{modified.toString()}</div>;
 };
@@ -84,5 +84,26 @@ describe("usePreviousModified", () => {
 			"to satisfy",
 			<div>false</div>,
 		);
+	});
+
+	it("execute effect action when defined", () => {
+		let actionValue = "before";
+
+		const effectAction = () => (actionValue = "after");
+
+		expect(
+			<Provider store={store}>
+				<MemoryRouter>
+					<TestComp initCount={10} value={14} effectAction={effectAction} />
+				</MemoryRouter>
+			</Provider>,
+			"when mounted",
+			"with event",
+			"click",
+			"to satisfy",
+			<div>true</div>,
+		);
+
+		expect(actionValue, "to equal", "after");
 	});
 });

--- a/src/hooks/usePreviousModified.test.js
+++ b/src/hooks/usePreviousModified.test.js
@@ -1,0 +1,88 @@
+import React from "react";
+import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import Immutable from "immutable";
+import sinon from "sinon";
+import usePreviousModified from "./usePreviousModified";
+import { useState } from "react";
+
+const TestComp = ({ initCount, value, predicate }) => {
+	const [count, setCount] = useState(initCount);
+	const modified = usePreviousModified(count, predicate);
+
+	return <div onClick={() => setCount(value)}>{modified.toString()}</div>;
+};
+
+describe("usePreviousModified", () => {
+	let store, state;
+	beforeEach(() => {
+		state = Immutable.fromJS({});
+		store = {
+			subscribe: () => {},
+			getState: () => state,
+			dispatch: sinon.spy().named("dispatch"),
+		};
+	});
+
+	it("display value as modified with default predicate", () =>
+		expect(
+			<Provider store={store}>
+				<MemoryRouter>
+					<TestComp initCount={0} value={1} />
+				</MemoryRouter>
+			</Provider>,
+			"when mounted",
+			"with event",
+			"click",
+			"to satisfy",
+			<div>true</div>,
+		));
+
+	it("display value as not modified default predicate", () =>
+		expect(
+			<Provider store={store}>
+				<MemoryRouter>
+					<TestComp initCount={10} value={10} />
+				</MemoryRouter>
+			</Provider>,
+			"when mounted",
+			"with event",
+			"click",
+			"to satisfy",
+			<div>false</div>,
+		));
+
+	it("display value as modified with custom predicate", () => {
+		const predicate = (p, c) => c >= 15;
+
+		expect(
+			<Provider store={store}>
+				<MemoryRouter>
+					<TestComp initCount={10} value={15} predicate={predicate} />
+				</MemoryRouter>
+			</Provider>,
+			"when mounted",
+			"with event",
+			"click",
+			"to satisfy",
+			<div>true</div>,
+		);
+	});
+
+	it("display value as not modified with custom predicate", () => {
+		const predicate = (p, c) => c >= 15;
+
+		expect(
+			<Provider store={store}>
+				<MemoryRouter>
+					<TestComp initCount={10} value={14} predicate={predicate} />
+				</MemoryRouter>
+			</Provider>,
+			"when mounted",
+			"with event",
+			"click",
+			"to satisfy",
+			<div>false</div>,
+		);
+	});
+});


### PR DESCRIPTION
If the parent scope state was closed, the scope tree was not expanded to see the current scope.

Story: #26826