### PR TITLE
Feature: AB#36199 Add activity messages in module list

### DIFF
--- a/docs/components.md
+++ b/docs/components.md
@@ -7,7 +7,7 @@
 - `applications`: A list of applications to be made available in the application selector. An application is defined as an object containing `url`, `name`, `iconUri` and `displayName` values.
 - `applicationId`: The `name` of the current application as given in `applications`.
 - `modules`: A list of modules provided by this application, given as objects containing an `id` (used to generate its URL), a `component` to render, and an `icon` and a `label` (`react-intl` message descriptor) to show in the sidebar menu. See [documentation](moduleFile.md).
-- `activeModules`: An array of module `id` to be shown as active (a red dot will appear by the icon).
+- `activeModules`: An object with module names as keys, where the values are either falsy (no notification), or an object. If the object has a `message` key, this will be shown as a notification tooltip. If the object has a `type` key (value should a a string of either `"confirm"`, `"warn"` or `"error"` as the case demands), this will be used to dermine the alert color.
 - `menuLabel`: The label for the topbar menu. Typically the logged-in user's email.
 - `menuItems`: A list of items in the topbar menu, given as objects containing `label` (`react-intl` message descriptor), `handler`function for selecting the item, and an `icon` id to show.
 - `noScope`: A flag. If set, scope selector will not be shown.

--- a/src/components/AppFrame/AppFrame.js
+++ b/src/components/AppFrame/AppFrame.js
@@ -81,7 +81,9 @@ AppFrame.displayName = "AppFrame";
 AppFrame.propTypes = {
 	applicationId: pt.string.isRequired,
 	modules: pt.array.isRequired,
-	activeModules: pt.array,
+	activeModules: pt.objectOf(
+		pt.oneOfType([pt.bool, pt.shape({ type: pt.string, message: pt.string })]),
+	),
 	menuMessages: pt.shape({
 		sign_out: ptLabel.isRequired,
 		preferences: ptLabel.isRequired,

--- a/src/components/AppFrame/AppFrame.js
+++ b/src/components/AppFrame/AppFrame.js
@@ -2,7 +2,6 @@ import React from "react";
 import pt from "prop-types";
 import styled, { css } from "styled-components";
 import { useSelector } from "react-redux";
-import { useLocation } from "react-router-dom";
 import { ifFlag, getThemeProp, unwrapImmutable } from "../../utils";
 import { getApplications } from "../../actions/applications";
 import useToggle from "../../hooks/useToggle";
@@ -58,12 +57,11 @@ const AppFrame = ({
 	const applications = unwrapImmutable(useSelector(localizedAppSelector));
 	useLoader(getApplications(), state => localizedAppSelector(state).size);
 	const [open, toggle, reset] = useToggle(initOpen);
-	const location = useLocation();
 	return (
 		<Base>
 			<ConnectedToastList />
 			<Topbar {...{ applications, applicationId, menuMessages }} onClick={reset} />
-			<Sidebar {...{ open, toggle, modules, activeModules }} path={location.pathname} />
+			<Sidebar {...{ open, toggle, modules, activeModules }} />
 			<ViewPort open={open} onClick={reset}>
 				{noScope ? (
 					<React.Fragment>

--- a/src/components/AppFrame/AppFrame.test.js
+++ b/src/components/AppFrame/AppFrame.test.js
@@ -39,7 +39,7 @@ describe("AppFrame", () => {
 		props = {
 			applicationId: "3",
 			modules: [],
-			activeModules: ["foo"],
+			activeModules: { foo: true },
 			menuLabel: "TestLabel",
 			menuMessages: {
 				sign_out: { id: "msg.signout", defaultMessage: "Sign out" },

--- a/src/components/AppFrame/MenuItem.js
+++ b/src/components/AppFrame/MenuItem.js
@@ -50,7 +50,30 @@ export const Alert = styled.div`
 
 export const AlertMessage = styled.div`
 	position: absolute;
+	z-index: 10000;
+	top: -1px;
+	transform: translateY(-50%);
+	left: 22px;
+	width: auto;
+	width: max-content;
+	border-radius: 5px;
+	padding: 10px 15px;
+	box-shadow: 0 2px 4px 0 rgba(0, 0, 0, 0.5);
+	color: ${getThemeProp(["colors", "textWhite"], "#efefef")};
 	background-color: ${getThemeProp(["colors", "toasts", props => props.type], "red")};
+	font-size: 11px;
+	font-weight: bold;
+
+	&::before {
+		content: "";
+		position: absolute;
+		top: 50%;
+		transform: translateY(-50%);
+		left: -10px;
+		border: solid transparent;
+		border-width: 5px 10px 5px 0;
+		border-right-color: ${getThemeProp(["colors", "toasts", props => props.type], "red")};
+	}
 `;
 
 export const MenuIcon = styled(Icon)`

--- a/src/components/AppFrame/MenuItem.js
+++ b/src/components/AppFrame/MenuItem.js
@@ -54,7 +54,7 @@ export const MenuIcon = styled(Icon)`
 `;
 
 export const Label = styled.span`
-	font-family: Roboto Condensed, sans-serif;
+	font-family: ${getThemeProp(["fonts", "header"], "sans-serif")};
 	font-size: 13px;
 	vertical-align: middle;
 	text-transform: uppercase;

--- a/src/components/AppFrame/MenuItem.js
+++ b/src/components/AppFrame/MenuItem.js
@@ -42,10 +42,15 @@ export const BlockWithA = Block.withComponent("a");
 
 export const Alert = styled.div`
 	border-radius: 50%;
-	border: 4px solid #ff0000;
+	border: 4px solid ${getThemeProp(["colors", "toasts", props => props.type], "red")};
 	position: absolute;
 	top: 0;
 	left: 27px;
+`;
+
+export const AlertMessage = styled.div`
+	position: absolute;
+	background-color: ${getThemeProp(["colors", "toasts", props => props.type], "red")};
 `;
 
 export const MenuIcon = styled(Icon)`
@@ -72,7 +77,15 @@ const MenuItem = ({ open = false, label = "", icon, alert, href, ...props }) => 
 	return (
 		<ItemWrapper to={href} {...props}>
 			<MenuIcon id={icon} />
-			{alert ? <Alert /> : null}
+			{alert ? (
+				<Alert type={alert.type}>
+					{alert.message ? (
+						<AlertMessage type={alert.type}>
+							<Text message={alert.message} />
+						</AlertMessage>
+					) : null}
+				</Alert>
+			) : null}
 			<Label show={open}>
 				<Text message={label} />
 			</Label>

--- a/src/components/AppFrame/MenuItem.test.js
+++ b/src/components/AppFrame/MenuItem.test.js
@@ -1,8 +1,9 @@
 import React from "react";
 import { Provider } from "react-redux";
+import { ThemeProvider } from "styled-components";
 import { MemoryRouter } from "react-router-dom";
 import { Ignore } from "unexpected-reaction";
-import MenuItem, { Block, MenuIcon, Label, Alert } from "./MenuItem";
+import MenuItem, { Block, MenuIcon, Label, Alert, AlertMessage } from "./MenuItem";
 
 const BlockWithA = Block.withComponent("a");
 
@@ -17,12 +18,7 @@ describe("MenuItem", () => {
 		expect(
 			<Provider store={store}>
 				<MemoryRouter>
-					<MenuItem
-						id="test"
-						href="/foo/test"
-						data-test-id="test"
-						icon="cake"
-					/>
+					<MenuItem id="test" href="/foo/test" data-test-id="test" icon="cake" />
 				</MemoryRouter>
 			</Provider>,
 			"when mounted",
@@ -106,6 +102,82 @@ describe("MenuItem", () => {
 			</MemoryRouter>,
 		));
 
+	it("shows activity type", () =>
+		expect(
+			<Provider store={store}>
+				<MemoryRouter>
+					<MenuItem
+						id="test"
+						href="/foo/test"
+						icon="cake"
+						label="Test"
+						alert={{ type: "confirm" }}
+					/>
+				</MemoryRouter>
+			</Provider>,
+			"when mounted",
+			"to satisfy",
+			<MemoryRouter>
+				<Block id="test" to="/foo/test">
+					<MenuIcon id="cake" />
+					<Alert type="confirm" />
+					<Label>Test</Label>
+				</Block>
+			</MemoryRouter>,
+		));
+
+	it("shows activity message", () =>
+		expect(
+			<Provider store={store}>
+				<MemoryRouter>
+					<MenuItem
+						id="test"
+						href="/foo/test"
+						icon="cake"
+						label="Test"
+						alert={{ message: "Test message" }}
+					/>
+				</MemoryRouter>
+			</Provider>,
+			"when mounted",
+			"to satisfy",
+			<MemoryRouter>
+				<Block id="test" to="/foo/test">
+					<MenuIcon id="cake" />
+					<Alert>
+						<AlertMessage>Test message</AlertMessage>
+					</Alert>
+					<Label>Test</Label>
+				</Block>
+			</MemoryRouter>,
+		));
+
+	it("shows activity type on messages", () =>
+		expect(
+			<Provider store={store}>
+				<MemoryRouter>
+					<MenuItem
+						id="test"
+						href="/foo/test"
+						icon="cake"
+						label="Test"
+						alert={{ message: "Test message", type: "warn" }}
+					/>
+				</MemoryRouter>
+			</Provider>,
+			"when mounted",
+			"to satisfy",
+			<MemoryRouter>
+				<Block id="test" to="/foo/test">
+					<MenuIcon id="cake" />
+					<Alert type="warn">
+						<AlertMessage type="warn">Test message</AlertMessage>
+					</Alert>
+					<Label>Test</Label>
+				</Block>
+			</MemoryRouter>,
+		));
+
 	describe("Block", () => {
 		it("sets text color to highlight if active", () =>
 			expect(
@@ -169,6 +241,50 @@ describe("MenuItem", () => {
 				"to have style rules satisfying",
 				"to contain",
 				"opacity: 0;",
+			));
+	});
+
+	describe("Alert", () => {
+		it("has a default color (red)", () =>
+			expect(
+				<Alert />,
+				"when mounted",
+				"to have style rules satisfying",
+				"to match",
+				/border: \d+px solid red/,
+			));
+
+		it("has a default color", () =>
+			expect(
+				<ThemeProvider theme={{ colors: { toasts: { test: "blue" } } }}>
+					<Alert type="test" />
+				</ThemeProvider>,
+				"when mounted",
+				"to have style rules satisfying",
+				"to match",
+				/border: \d+px solid blue/,
+			));
+	});
+
+	describe("AlertMessage", () => {
+		it("has a default color (red)", () =>
+			expect(
+				<AlertMessage message="Test" />,
+				"when mounted",
+				"to have style rules satisfying",
+				"to contain",
+				"background-color: red",
+			));
+
+		it("has a default color", () =>
+			expect(
+				<ThemeProvider theme={{ colors: { toasts: { test: "blue" } } }}>
+					<AlertMessage message="Test" type="test" />
+				</ThemeProvider>,
+				"when mounted",
+				"to have style rules satisfying",
+				"to contain",
+				"background-color: blue",
 			));
 	});
 });

--- a/src/components/AppFrame/Sidebar.js
+++ b/src/components/AppFrame/Sidebar.js
@@ -77,7 +77,7 @@ const Sidebar = ({ open, toggle, modules = [], activeModules = [] }) => {
 					key={item.id}
 					{...item}
 					open={open}
-					alert={activeModules.includes(item.id)}
+					alert={activeModules[item.id] || false}
 				/>
 			))}
 			<Logo />

--- a/src/components/AppFrame/Sidebar.js
+++ b/src/components/AppFrame/Sidebar.js
@@ -1,6 +1,7 @@
 import React from "react";
 import { useSelector } from "react-redux";
 import styled, { withTheme } from "styled-components";
+import { useLocation } from "react-router-dom";
 import { getThemeProp } from "../../utils";
 import { getCurrentScope } from "../../selectors/navigation";
 import MenuItem from "./MenuItem";
@@ -30,15 +31,16 @@ export const MenuToggle = withTheme(({ open, toggle, theme }) => (
 
 const useEnhancement = (id, path) => {
 	const scope = useSelector(getCurrentScope);
+	const location = useLocation();
 	return {
 		href: `/${scope}/${id}`,
-		active: path.startsWith(`/${scope}/${id}`),
+		active: location.pathname.startsWith(`/${scope}/${id}`),
 		id,
 	};
 };
 
-export const EnhancedMenuItem = ({ path, id, ...props }) => (
-	<MenuItem {...props} {...useEnhancement(id, path)} />
+export const EnhancedMenuItem = ({ id, ...props }) => (
+	<MenuItem {...props} {...useEnhancement(id)} />
 );
 
 const LogoSvg = styled.svg`
@@ -66,7 +68,7 @@ export const Logo = () => (
 	</LogoSvg>
 );
 
-const Sidebar = ({ open, toggle, modules = [], activeModules = [], path = "" }) => {
+const Sidebar = ({ open, toggle, modules = [], activeModules = [] }) => {
 	return (
 		<Bar open={open}>
 			<MenuToggle open={open} toggle={toggle} />
@@ -75,7 +77,6 @@ const Sidebar = ({ open, toggle, modules = [], activeModules = [], path = "" }) 
 					key={item.id}
 					{...item}
 					open={open}
-					path={path}
 					alert={activeModules.includes(item.id)}
 				/>
 			))}

--- a/src/components/AppFrame/Sidebar.test.js
+++ b/src/components/AppFrame/Sidebar.test.js
@@ -22,7 +22,7 @@ describe("Sidebar", () => {
 			},
 		];
 		state = Immutable.fromJS({
-			navigation: { route: { match: {} } },
+			navigation: { route: { match: { params: { scope: "Global" } } } },
 		});
 		store = {
 			subscribe: () => {},
@@ -35,8 +35,8 @@ describe("Sidebar", () => {
 		expect(
 			<Provider store={store}>
 				<ThemeProvider theme={{}}>
-					<MemoryRouter>
-						<Sidebar modules={modules} path="/Global/second" />
+					<MemoryRouter initialEntries={["/Global/second"]}>
+						<Sidebar modules={modules} />
 					</MemoryRouter>
 				</ThemeProvider>
 			</Provider>,
@@ -44,21 +44,11 @@ describe("Sidebar", () => {
 			"to satisfy",
 			<Provider store={store}>
 				<ThemeProvider theme={{}}>
-					<MemoryRouter>
+					<MemoryRouter initialEntries={["/Global/second"]}>
 						<Bar>
 							<MenuToggle />
-							<EnhancedMenuItem
-								icon="cars"
-								id="first"
-								label="First page"
-								path="/Global/second"
-							/>
-							<EnhancedMenuItem
-								icon="person"
-								id="second"
-								label="Second page"
-								path="/Global/second"
-							/>
+							<EnhancedMenuItem icon="cars" id="first" label="First page" />
+							<EnhancedMenuItem icon="person" id="second" label="Second page" />
 							<Logo />
 						</Bar>
 					</MemoryRouter>
@@ -70,12 +60,8 @@ describe("Sidebar", () => {
 		expect(
 			<Provider store={store}>
 				<ThemeProvider theme={{}}>
-					<MemoryRouter>
-						<Sidebar
-							modules={modules}
-							path="/Global/second"
-							activeModules={["first"]}
-						/>
+					<MemoryRouter initialEntries={["/Global/second"]}>
+						<Sidebar modules={modules} activeModules={["first"]} />
 					</MemoryRouter>
 				</ThemeProvider>
 			</Provider>,
@@ -83,22 +69,11 @@ describe("Sidebar", () => {
 			"to satisfy",
 			<Provider store={store}>
 				<ThemeProvider theme={{}}>
-					<MemoryRouter>
+					<MemoryRouter initialEntries={["/Global/second"]}>
 						<Bar>
 							<MenuToggle />
-							<EnhancedMenuItem
-								icon="cars"
-								id="first"
-								label="First page"
-								path="/Global/second"
-								alert
-							/>
-							<EnhancedMenuItem
-								icon="person"
-								id="second"
-								label="Second page"
-								path="/Global/second"
-							/>
+							<EnhancedMenuItem icon="cars" id="first" label="First page" alert />
+							<EnhancedMenuItem icon="person" id="second" label="Second page" />
 							<Logo />
 						</Bar>
 					</MemoryRouter>
@@ -110,8 +85,8 @@ describe("Sidebar", () => {
 		expect(
 			<Provider store={store}>
 				<ThemeProvider theme={{}}>
-					<MemoryRouter>
-						<Sidebar open modules={modules} path="/Global/second" />
+					<MemoryRouter initialEntries={["/Global/second"]}>
+						<Sidebar open modules={modules} />
 					</MemoryRouter>
 				</ThemeProvider>
 			</Provider>,
@@ -119,23 +94,11 @@ describe("Sidebar", () => {
 			"to satisfy",
 			<Provider store={store}>
 				<ThemeProvider theme={{}}>
-					<MemoryRouter>
+					<MemoryRouter initialEntries={["/Global/second"]}>
 						<Bar>
 							<MenuToggle open />
-							<EnhancedMenuItem
-								open
-								icon="cars"
-								id="first"
-								label="First page"
-								path="/Global/second"
-							/>
-							<EnhancedMenuItem
-								open
-								icon="person"
-								id="second"
-								label="Second page"
-								path="/Global/second"
-							/>
+							<EnhancedMenuItem open icon="cars" id="first" label="First page" />
+							<EnhancedMenuItem open icon="person" id="second" label="Second page" />
 							<Logo />
 						</Bar>
 					</MemoryRouter>
@@ -205,8 +168,8 @@ describe("EnhancedMenuItem", () => {
 	it("sets the active flag if path matches href", () =>
 		expect(
 			<Provider store={store}>
-				<MemoryRouter>
-					<EnhancedMenuItem id="route" path="/Global/route/subpath" />
+				<MemoryRouter initialEntries={["/Global/route/subpath"]}>
+					<EnhancedMenuItem id="route" />
 				</MemoryRouter>
 			</Provider>,
 			"when mounted",
@@ -298,11 +261,7 @@ describe("MenuToggle", () => {
 				"when mounted",
 				"to satisfy",
 				<Provider store={store}>
-					<MenuItem
-						menuToggle
-						icon="closed"
-						onClick={expect.it("to be a function")}
-					/>
+					<MenuItem menuToggle icon="closed" onClick={expect.it("to be a function")} />
 				</Provider>,
 			));
 
@@ -318,12 +277,7 @@ describe("MenuToggle", () => {
 				"when mounted",
 				"to satisfy",
 				<Provider store={store}>
-					<MenuItem
-						menuToggle
-						open
-						icon="open"
-						onClick={expect.it("to be a function")}
-					/>
+					<MenuItem menuToggle open icon="open" onClick={expect.it("to be a function")} />
 				</Provider>,
 			));
 	});

--- a/src/components/AppFrame/Sidebar.test.js
+++ b/src/components/AppFrame/Sidebar.test.js
@@ -61,7 +61,7 @@ describe("Sidebar", () => {
 			<Provider store={store}>
 				<ThemeProvider theme={{}}>
 					<MemoryRouter initialEntries={["/Global/second"]}>
-						<Sidebar modules={modules} activeModules={["first"]} />
+						<Sidebar modules={modules} activeModules={{ first: { type: "confirm" } }} />
 					</MemoryRouter>
 				</ThemeProvider>
 			</Provider>,
@@ -72,7 +72,12 @@ describe("Sidebar", () => {
 					<MemoryRouter initialEntries={["/Global/second"]}>
 						<Bar>
 							<MenuToggle />
-							<EnhancedMenuItem icon="cars" id="first" label="First page" alert />
+							<EnhancedMenuItem
+								icon="cars"
+								id="first"
+								label="First page"
+								alert={{ type: "confirm" }}
+							/>
 							<EnhancedMenuItem icon="person" id="second" label="Second page" />
 							<Logo />
 						</Bar>


### PR DESCRIPTION
AppFrame's activeModules prop has changed, it is now an object instead of an array, module names are keys. Values should be boolean or objects of shape `{ type: ("confirm"|"warn"|"error")<string:optional>, message: <string|intlMessage:optional> }`. Boolean true shows a simple bright red marker at the module menu item. Setting `type` displays the marker in a color suiting the type of notification. Setting `message` will display a tooltip-like message with the activity notification. It is up to the application to add and remove mesaages as needed.

