### PR TITLE
Bugs/27444 applications icon not visible

### DIFF
--- a/src/actions/applications.js
+++ b/src/actions/applications.js
@@ -11,7 +11,7 @@ export const [
 ] = makeActionTypes(GET_APPLICATIONS);
 
 export const getApplications = () =>
-	makeOrcApiAction(GET_APPLICATIONS, buildUrl(["applications"]));
+	makeOrcApiAction(GET_APPLICATIONS, buildUrl(["my", "applications"]));
 
 export const GET_MY_APPLICATION = "GET_MY_APPLICATION";
 

--- a/src/actions/applications.test.js
+++ b/src/actions/applications.test.js
@@ -31,7 +31,7 @@ describe("getApplications", () => {
 					GET_APPLICATIONS_SUCCESS,
 					GET_APPLICATIONS_FAILURE,
 				],
-				endpoint: 'URL: applications ""',
+				endpoint: 'URL: my/applications ""',
 				method: "GET",
 				body: undefined,
 				credentials: "include",


### PR DESCRIPTION
Application icons are not visible when the users roles are limited, e.g. a user having only Orders/Editor.