### PR TITLE
Bugs/36423 title and chevron not visible enough

### DIFF
--- a/src/components/AppFrame/Topbar.js
+++ b/src/components/AppFrame/Topbar.js
@@ -70,7 +70,7 @@ export const AppBox = styled.div`
 
 export const AppLabel = styled.div`
 	background-color: #000000;
-	color: ${getThemeProp(["colors", "application", "base"], "#ffffff")};
+	color: ${getThemeProp(["colors", "application", "primary"], "#ffffff")};
 	font-family: ${getThemeProp(["fonts", "header"], "sans-serif")};
 	font-size: 14px;
 	text-transform: uppercase;

--- a/src/components/DropMenu/Anchor.js
+++ b/src/components/DropMenu/Anchor.js
@@ -4,17 +4,20 @@ import { getThemeProp, ifFlag } from "../../utils";
 import Icon from "../Icon";
 
 export const Header = styled.div`
+	display: flex;
 	cursor: pointer;
 	color: ${ifFlag(
 		"open",
-		getThemeProp(["colors", "application", "base"], "#ccc"),
+		getThemeProp(["colors", "application", "primary"], "#ccc"),
 		"#ccc",
 	)};
 
 	&:hover {
-		color: ${getThemeProp(["colors", "application", "base"], "#ccc")};
+		color: ${getThemeProp(["colors", "application", "primary"], "#ccc")};
 	}
 `;
+
+export const IndicatorWrapper = styled.div``;
 
 export const Indicator = styled(Icon).attrs(props => ({
 	id: ifFlag(
@@ -23,19 +26,21 @@ export const Indicator = styled(Icon).attrs(props => ({
 		getThemeProp(["icons", "indicators", "down"], "chevron-down"),
 	)(props),
 }))`
-	font-size: 10px;
+	font-size: 12px;
 	padding: 0 11px;
 	color: ${ifFlag(
 		"open",
 		"#ccc",
-		getThemeProp(["colors", "application", "base"], "#ccc"),
+		getThemeProp(["colors", "application", "primary"], "#ccc"),
 	)};
 `;
 
 const Anchor = ({ id, onClick, className, menuLabel, open }) => (
 	<Header {...{ id, onClick, className, open }}>
 		{menuLabel}
-		<Indicator open={open} />
+		<IndicatorWrapper>
+			<Indicator open={open} />
+		</IndicatorWrapper>
 	</Header>
 );
 

--- a/src/components/DropMenu/Anchor.js
+++ b/src/components/DropMenu/Anchor.js
@@ -17,8 +17,6 @@ export const Header = styled.div`
 	}
 `;
 
-export const IndicatorWrapper = styled.div``;
-
 export const Indicator = styled(Icon).attrs(props => ({
 	id: ifFlag(
 		"open",
@@ -38,9 +36,7 @@ export const Indicator = styled(Icon).attrs(props => ({
 const Anchor = ({ id, onClick, className, menuLabel, open }) => (
 	<Header {...{ id, onClick, className, open }}>
 		{menuLabel}
-		<IndicatorWrapper>
-			<Indicator open={open} />
-		</IndicatorWrapper>
+		<Indicator open={open} />
 	</Header>
 );
 

--- a/src/components/DropMenu/Anchor.test.js
+++ b/src/components/DropMenu/Anchor.test.js
@@ -1,5 +1,5 @@
 import React from "react";
-import Anchor, { Header, Indicator } from "./Anchor";
+import Anchor, { Header, Indicator, IndicatorWrapper } from "./Anchor";
 
 describe("Anchor", () => {
 	it("renders a closed menu anchor", () => {
@@ -15,7 +15,9 @@ describe("Anchor", () => {
 			"to satisfy",
 			<Header id="testAnchor" onClick={onClick} className="propagateThis">
 				A Label
-				<Indicator />
+				<IndicatorWrapper>
+					<Indicator />
+				</IndicatorWrapper>
 			</Header>,
 		);
 	});
@@ -27,7 +29,9 @@ describe("Anchor", () => {
 			"to satisfy",
 			<Header open className="propagateThis">
 				A Label
-				<Indicator open />
+				<IndicatorWrapper>
+					<Indicator open />
+				</IndicatorWrapper>
 			</Header>,
 		));
 
@@ -35,7 +39,7 @@ describe("Anchor", () => {
 		let theme;
 		beforeEach(() => {
 			theme = {
-				colors: { application: { base: "#ff00ff" } },
+				colors: { application: { primary: "#ff00ff" } },
 			};
 		});
 
@@ -62,7 +66,7 @@ describe("Anchor", () => {
 		let theme;
 		beforeEach(() => {
 			theme = {
-				colors: { application: { base: "#ff00ff" } },
+				colors: { application: { primary: "#ff00ff" } },
 			};
 		});
 

--- a/src/components/DropMenu/Anchor.test.js
+++ b/src/components/DropMenu/Anchor.test.js
@@ -1,5 +1,5 @@
 import React from "react";
-import Anchor, { Header, Indicator, IndicatorWrapper } from "./Anchor";
+import Anchor, { Header, Indicator } from "./Anchor";
 
 describe("Anchor", () => {
 	it("renders a closed menu anchor", () => {
@@ -15,9 +15,7 @@ describe("Anchor", () => {
 			"to satisfy",
 			<Header id="testAnchor" onClick={onClick} className="propagateThis">
 				A Label
-				<IndicatorWrapper>
-					<Indicator />
-				</IndicatorWrapper>
+				<Indicator />
 			</Header>,
 		);
 	});
@@ -29,9 +27,7 @@ describe("Anchor", () => {
 			"to satisfy",
 			<Header open className="propagateThis">
 				A Label
-				<IndicatorWrapper>
-					<Indicator open />
-				</IndicatorWrapper>
+				<Indicator open />
 			</Header>,
 		));
 

--- a/src/components/DropMenu/DropMenu.test.js
+++ b/src/components/DropMenu/DropMenu.test.js
@@ -5,7 +5,7 @@ import { act } from "react-dom/test-utils";
 import { mount, simulate } from "unexpected-reaction";
 import sinon from "sinon";
 import DropMenu, { Wrapper } from "./index";
-import Anchor, { Header, Indicator } from "./Anchor";
+import Anchor, { Header, Indicator, IndicatorWrapper } from "./Anchor";
 import Menu, { Drawer, List, Item, ItemIcon } from "./Menu";
 import { getStyledClassSelector } from "../../utils/testUtils";
 
@@ -70,7 +70,9 @@ describe("DropMenu", () => {
 			<Wrapper className="test-class">
 				<Header id="testAnchor" open>
 					TestLabel
-					<Indicator open={true} />
+					<IndicatorWrapper>
+						<Indicator open={true} />
+					</IndicatorWrapper>
 				</Header>
 				<Drawer in>
 					<List id="testDropdown">
@@ -286,13 +288,17 @@ describe("DropMenu", () => {
 					<Wrapper className="test-class-1">
 						<Header>
 							TestLabel 1
-							<Indicator />
+							<IndicatorWrapper>
+								<Indicator />
+							</IndicatorWrapper>
 						</Header>
 					</Wrapper>
 					<Wrapper className="test-class-2">
 						<Header>
 							TestLabel 2
-							<Indicator />
+							<IndicatorWrapper>
+								<Indicator />
+							</IndicatorWrapper>
 						</Header>
 					</Wrapper>
 				</div>,
@@ -322,13 +328,17 @@ describe("DropMenu", () => {
 					<Wrapper className="test-class-1">
 						<Header>
 							TestLabel 1
-							<Indicator />
+							<IndicatorWrapper>
+								<Indicator />
+							</IndicatorWrapper>
 						</Header>
 					</Wrapper>
 					<Wrapper className="test-class-2">
 						<Header>
 							TestLabel 2
-							<Indicator />
+							<IndicatorWrapper>
+								<Indicator />
+							</IndicatorWrapper>
 						</Header>
 					</Wrapper>
 				</div>,
@@ -343,13 +353,17 @@ describe("DropMenu", () => {
 					<Wrapper className="test-class-1">
 						<Header>
 							TestLabel 1
-							<Indicator />
+							<IndicatorWrapper>
+								<Indicator />
+							</IndicatorWrapper>
 						</Header>
 					</Wrapper>
 					<Wrapper className="test-class-2">
 						<Header open>
 							TestLabel 2
-							<Indicator open={true} />
+							<IndicatorWrapper>
+								<Indicator open={true} />
+							</IndicatorWrapper>
 						</Header>
 						<Drawer in>
 							<List>
@@ -379,7 +393,9 @@ describe("DropMenu", () => {
 					<Wrapper className="test-class-1">
 						<Header open>
 							TestLabel 1
-							<Indicator open={true} />
+							<IndicatorWrapper>
+								<Indicator open={true} />
+							</IndicatorWrapper>
 						</Header>
 						<Drawer in>
 							<List>
@@ -397,7 +413,9 @@ describe("DropMenu", () => {
 					<Wrapper className="test-class-2">
 						<Header>
 							TestLabel 2
-							<Indicator />
+							<IndicatorWrapper>
+								<Indicator />
+							</IndicatorWrapper>
 						</Header>
 					</Wrapper>
 				</div>,

--- a/src/components/DropMenu/DropMenu.test.js
+++ b/src/components/DropMenu/DropMenu.test.js
@@ -5,7 +5,7 @@ import { act } from "react-dom/test-utils";
 import { mount, simulate } from "unexpected-reaction";
 import sinon from "sinon";
 import DropMenu, { Wrapper } from "./index";
-import Anchor, { Header, Indicator, IndicatorWrapper } from "./Anchor";
+import Anchor, { Header, Indicator } from "./Anchor";
 import Menu, { Drawer, List, Item, ItemIcon } from "./Menu";
 import { getStyledClassSelector } from "../../utils/testUtils";
 
@@ -70,9 +70,7 @@ describe("DropMenu", () => {
 			<Wrapper className="test-class">
 				<Header id="testAnchor" open>
 					TestLabel
-					<IndicatorWrapper>
-						<Indicator open={true} />
-					</IndicatorWrapper>
+					<Indicator open={true} />
 				</Header>
 				<Drawer in>
 					<List id="testDropdown">
@@ -288,17 +286,13 @@ describe("DropMenu", () => {
 					<Wrapper className="test-class-1">
 						<Header>
 							TestLabel 1
-							<IndicatorWrapper>
-								<Indicator />
-							</IndicatorWrapper>
+							<Indicator />
 						</Header>
 					</Wrapper>
 					<Wrapper className="test-class-2">
 						<Header>
 							TestLabel 2
-							<IndicatorWrapper>
-								<Indicator />
-							</IndicatorWrapper>
+							<Indicator />
 						</Header>
 					</Wrapper>
 				</div>,
@@ -328,17 +322,13 @@ describe("DropMenu", () => {
 					<Wrapper className="test-class-1">
 						<Header>
 							TestLabel 1
-							<IndicatorWrapper>
-								<Indicator />
-							</IndicatorWrapper>
+							<Indicator />
 						</Header>
 					</Wrapper>
 					<Wrapper className="test-class-2">
 						<Header>
 							TestLabel 2
-							<IndicatorWrapper>
-								<Indicator />
-							</IndicatorWrapper>
+							<Indicator />
 						</Header>
 					</Wrapper>
 				</div>,
@@ -353,17 +343,13 @@ describe("DropMenu", () => {
 					<Wrapper className="test-class-1">
 						<Header>
 							TestLabel 1
-							<IndicatorWrapper>
-								<Indicator />
-							</IndicatorWrapper>
+							<Indicator />
 						</Header>
 					</Wrapper>
 					<Wrapper className="test-class-2">
 						<Header open>
 							TestLabel 2
-							<IndicatorWrapper>
-								<Indicator open={true} />
-							</IndicatorWrapper>
+							<Indicator open={true} />
 						</Header>
 						<Drawer in>
 							<List>
@@ -393,9 +379,7 @@ describe("DropMenu", () => {
 					<Wrapper className="test-class-1">
 						<Header open>
 							TestLabel 1
-							<IndicatorWrapper>
-								<Indicator open={true} />
-							</IndicatorWrapper>
+							<Indicator open={true} />
 						</Header>
 						<Drawer in>
 							<List>
@@ -413,9 +397,7 @@ describe("DropMenu", () => {
 					<Wrapper className="test-class-2">
 						<Header>
 							TestLabel 2
-							<IndicatorWrapper>
-								<Indicator />
-							</IndicatorWrapper>
+							<Indicator />
 						</Header>
 					</Wrapper>
 				</div>,


### PR DESCRIPTION
Based on our UX/UI expert, the new base color was not dark enough for other components in the OMS but it is still fine for the TopBar components. I also had to change this library to reflect those requirements. Also, the drop down menu chevron was a bit too small to his taste.