### PR TITLE
Add a common column wrapper to be used with lists

### DIFF
--- a/docs/components.md
+++ b/docs/components.md
@@ -43,6 +43,28 @@ See also the more [detailed documentation for list components](lists.md).
 
 Shows a pretty checkbox. The same props are accepted as for `<input type="checked" />` elements. Use `value` for whether the checkbox is checked or not, rather than `checked`. If no `id` is passed, one will be generated and used.
 
+## ColumnWrapper
+
+This is a default column wrapper available to be used by the applications.  This will ensure all applications experience the same behavior for columns used in lists.
+
+Here is some sample code on usage:
+
+> ```
+> const LocationList = () => {
+> 	const scope = useSelector(getCurrentScope);
+> 	const name = "locationList" + scope;
+> 	const locations = unwrapImmutable(useSelector(mappedLocationListSelector));
+> 	useLoader(getLocations(scope), locationListLength);
+> 
+> 	return (
+> 		<ColumnWrapper>
+> 			<Toolbar name={name} tools={[]} />
+> 			<List {...{ name, columnDefs, rows: locations }} />
+> 		</ColumnWrapper>
+> 	);
+> };
+> ```
+
 ## DevPages
 
 - `children`: Children of the component will be rendered on routes not starting with `/dev`.

--- a/src/components/ColumnWrapper.js
+++ b/src/components/ColumnWrapper.js
@@ -1,0 +1,11 @@
+import styled from "styled-components";
+
+const Wrapper = styled.div`
+	flex: 0 1 100%;
+	display: flex;
+	flex-direction: column;
+	min-height: 0;
+	min-width: 0;
+`;
+
+export default Wrapper;


### PR DESCRIPTION
Currently, Orckestra apps use a stand alone ColumnWrapper.  This common one can be provided to allow changes to be done for all applications.