### PR TITLE
Separate DropMenu from Anchor

### DIFF
--- a/docs/components.md
+++ b/docs/components.md
@@ -64,12 +64,10 @@ Inserts a set of developer pages to be found under `/dev/<page>`. In production,
 
 ## DropMenu
 
-- `menuLabel`: The menu anchor label text.
 - `menuItems`: A list of objects with `label` and `handler` properties. The former is the text to show, the latter the function to call on clicking the item.
 - `alignRight`: A flag that when set causes the menu to be rendered to align with the right edge of the anchor element, instead of the default left.
-- `AnchorComponent`: An optional component which will be used to render the menu anchor instead of the default. It will be passed `id`, `menuLabel`, and `open` props, as well as an `onClick` prop that will open the menu.
 
-A simple menu component that will show a list of items when clicked. Assigning it a class will apply it to the wrapper element, allowing it to be positioned if necessary.
+A simple menu component that will show a list of items when clicked. Assigning it a class will apply it to the wrapper element, allowing it to be positioned if necessary. This component will wrap its children with a click handler that opens the menu, and will pass its state as flag prop `open` to child components to enable showing style differences.
 
 ## Form
 

--- a/src/components/AppFrame/Anchor.js
+++ b/src/components/AppFrame/Anchor.js
@@ -6,6 +6,14 @@ import Icon from "../Icon";
 export const Header = styled.div`
 	display: flex;
 	cursor: pointer;
+	box-sizing: border-box;
+	font-family: ${getThemeProp(["fonts", "header"], "sans-serif")};
+	font-size: 12px;
+	text-transform: uppercase;
+	height: 40px;
+	min-width: 180px;
+	padding-top: 14px;
+	padding-right: 14px;
 	color: ${ifFlag(
 		"open",
 		getThemeProp(["colors", "application", "primary"], "#ccc"),
@@ -33,8 +41,8 @@ export const Indicator = styled(Icon).attrs(props => ({
 	)};
 `;
 
-const Anchor = ({ id, onClick, className, menuLabel, open }) => (
-	<Header {...{ id, onClick, className, open }}>
+const Anchor = ({ menuLabel, open }) => (
+	<Header {...{ open }}>
 		{menuLabel}
 		<Indicator open={open} />
 	</Header>

--- a/src/components/AppFrame/Anchor.test.js
+++ b/src/components/AppFrame/Anchor.test.js
@@ -3,29 +3,23 @@ import Anchor, { Header, Indicator } from "./Anchor";
 
 describe("Anchor", () => {
 	it("renders a closed menu anchor", () => {
-		const onClick = () => {};
 		expect(
-			<Anchor
-				id="testAnchor"
-				onClick={onClick}
-				menuLabel="A Label"
-				className="propagateThis"
-			/>,
+			<Anchor menuLabel="A Label" />,
 			"when mounted",
 			"to satisfy",
-			<Header id="testAnchor" onClick={onClick} className="propagateThis">
+			<Header open={false}>
 				A Label
-				<Indicator />
+				<Indicator open={false} />
 			</Header>,
 		);
 	});
 
 	it("renders an open menu anchor", () =>
 		expect(
-			<Anchor open menuLabel="A Label" className="propagateThis" />,
+			<Anchor open menuLabel="A Label" />,
 			"when mounted",
 			"to satisfy",
-			<Header open className="propagateThis">
+			<Header open>
 				A Label
 				<Indicator open />
 			</Header>,

--- a/src/components/AppFrame/Topbar.js
+++ b/src/components/AppFrame/Topbar.js
@@ -10,7 +10,7 @@ import { PREFS_NAME } from "./Preferences";
 import { ABOUT_NAME } from "./About";
 import ApplicationSelector from "./ApplicationSelector";
 import DropMenu from "../DropMenu";
-import Anchor from "../DropMenu/Anchor";
+import Anchor from "./Anchor";
 import Help from "./Help";
 
 export const Wrapper = styled.div`
@@ -48,20 +48,14 @@ export const useMenuProps = messages => {
 	};
 };
 
-export const StyledAnchor = styled(Anchor)`
-	box-sizing: border-box;
-	font-family: ${getThemeProp(["fonts", "header"], "sans-serif")};
-	font-size: 12px;
-	text-transform: uppercase;
-	height: 40px;
-	min-width: 180px;
-	padding-top: 14px;
-	padding-right: 14px;
-`;
-
-export const Menu = ({ messages }) => (
-	<DropMenu {...useMenuProps(messages)} AnchorComponent={StyledAnchor} />
-);
+export const Menu = ({ messages }) => {
+	const { menuLabel, ...menuProps } = useMenuProps(messages);
+	return (
+		<DropMenu {...menuProps}>
+			<Anchor menuLabel={menuLabel} />
+		</DropMenu>
+	);
+};
 
 export const AppBox = styled.div`
 	height: 100%;

--- a/src/components/DropMenu/DropMenu.test.js
+++ b/src/components/DropMenu/DropMenu.test.js
@@ -3,47 +3,50 @@ import ReactDOM from "react-dom";
 import { Provider } from "react-redux";
 import { act } from "react-dom/test-utils";
 import sinon from "sinon";
-import DropMenu, { Wrapper } from "./index";
-import Anchor, { Header, Indicator } from "./Anchor";
+import DropMenu, { AnchorWrapper, Wrapper } from "./index";
 import Menu, { Drawer, List, Item, ItemIcon } from "./Menu";
 import { getStyledClassSelector } from "../../utils/testUtils";
 
-const TestAnchor = ({ id, onClick, menuLabel, className, open }) => (
-	<div
-		id={id}
-		onClick={onClick}
-		className={className}
-		data-open={open}
-		data-label={menuLabel}
-	/>
+const TestAnchor = ({ id, onClick, className, open }) => (
+	<div id={id} onClick={onClick} className={className} data-open={open}>
+		Test anchor
+	</div>
 );
 
 describe("DropMenu", () => {
 	it("renders an anchor and a menu", () =>
 		expect(
-			<DropMenu id="test" menuLabel="TestLabel" menuItems={[]} className="test-class" />,
+			<DropMenu id="test" menuItems={[]} className="test-class">
+				TestLabel
+			</DropMenu>,
 			"when mounted",
 			"to satisfy",
 			<Wrapper className="test-class">
-				<Anchor id="testAnchor" menuLabel="TestLabel" />
+				<AnchorWrapper id="testAnchor">TestLabel</AnchorWrapper>
 				<Menu id="testDropdown" menuItems={[]} />
 			</Wrapper>,
 		));
 
 	it("flags anchor and menu when open", () =>
 		expect(
-			<DropMenu id="test" initOpen menuLabel="TestLabel" menuItems={[]} />,
+			<DropMenu id="test" initOpen menuItems={[]}>
+				TestLabel
+			</DropMenu>,
 			"when mounted",
 			"to satisfy",
 			<Wrapper>
-				<Anchor id="testAnchor" open menuLabel="TestLabel" />
+				<AnchorWrapper id="testAnchor" open>
+					TestLabel
+				</AnchorWrapper>
 				<Menu id="testDropdown" open menuItems={[]} />
 			</Wrapper>,
 		));
 
 	it("renders a right-aligned menu on demand", () =>
 		expect(
-			<DropMenu id="test" initOpen menuLabel="TestLabel" menuItems={[]} alignRight />,
+			<DropMenu id="test" initOpen menuItems={[]} alignRight>
+				TestLabel
+			</DropMenu>,
 			"when mounted",
 			"to contain",
 			<Menu id="testDropdown" open menuItems={[]} alignRight />,
@@ -54,23 +57,23 @@ describe("DropMenu", () => {
 			<Provider store={{ getState: () => ({}), subscribe: () => {}, dispatch: () => {} }}>
 				<DropMenu
 					id="test"
-					menuLabel="TestLabel"
 					menuItems={[
 						{ label: "First", icon: "one", handler: () => {} },
 						{ label: "Second", icon: "two", handler: () => {} },
 					]}
 					className="test-class"
-				/>
+				>
+					TestLabel
+				</DropMenu>
 			</Provider>,
 			"when mounted",
 			"with event",
 			{ type: "click", target: "#testAnchor" },
 			"to satisfy",
 			<Wrapper className="test-class">
-				<Header id="testAnchor" open>
+				<AnchorWrapper id="testAnchor" open>
 					TestLabel
-					<Indicator open={true} />
-				</Header>
+				</AnchorWrapper>
 				<Drawer in>
 					<List id="testDropdown">
 						<Item>
@@ -98,13 +101,14 @@ describe("DropMenu", () => {
 				>
 					<DropMenu
 						id="test"
-						menuLabel="TestLabel"
 						menuItems={[
 							{ label: "First", icon: "one", handler: () => {} },
 							{ label: "Second", icon: "two", handler: () => {} },
 						]}
 						className="test-class"
-					/>
+					>
+						TestLabel
+					</DropMenu>
 				</Provider>
 			</div>,
 			menuNode,
@@ -120,7 +124,13 @@ describe("DropMenu", () => {
 			act(() => {
 				outside.click();
 			});
-			expect(menu, "to contain", <Anchor id="testAnchor" menuLabel="TestLabel" />);
+			expect(
+				menu,
+				"to contain",
+				<AnchorWrapper id="testAnchor" open={false}>
+					TestLabel
+				</AnchorWrapper>,
+			);
 			act(() => {
 				clock.tick(1000); // Wait for the menu to unrender
 			});
@@ -132,37 +142,33 @@ describe("DropMenu", () => {
 		}
 	});
 
-	describe("custom anchor", () => {
+	describe("component child", () => {
 		it("renders an anchor and a menu", () =>
 			expect(
-				<DropMenu
-					id="test"
-					menuLabel="TestLabel"
-					menuItems={[]}
-					className="test-class"
-					AnchorComponent={TestAnchor}
-				/>,
+				<DropMenu id="test" menuItems={[]} className="test-class">
+					<TestAnchor />
+				</DropMenu>,
 				"when mounted",
 				"to satisfy",
 				<Wrapper className="test-class">
-					<TestAnchor id="testAnchor" menuLabel="TestLabel" />
+					<AnchorWrapper id="testAnchor">
+						<TestAnchor />
+					</AnchorWrapper>
 					<Menu id="testDropdown" menuItems={[]} />
 				</Wrapper>,
 			));
 
-		it("flags anchor and menu when open", () =>
+		it("flags children when open", () =>
 			expect(
-				<DropMenu
-					id="test"
-					initOpen
-					menuLabel="TestLabel"
-					menuItems={[]}
-					AnchorComponent={TestAnchor}
-				/>,
+				<DropMenu id="test" initOpen menuItems={[]}>
+					<TestAnchor />
+				</DropMenu>,
 				"when mounted",
 				"to satisfy",
 				<Wrapper>
-					<TestAnchor id="testAnchor" open menuLabel="TestLabel" />
+					<AnchorWrapper id="testAnchor" open>
+						<TestAnchor open />
+					</AnchorWrapper>
 					<Menu id="testDropdown" open menuItems={[]} />
 				</Wrapper>,
 			));
@@ -174,21 +180,23 @@ describe("DropMenu", () => {
 				>
 					<DropMenu
 						id="test"
-						menuLabel="TestLabel"
 						menuItems={[
 							{ label: "First", icon: "one", handler: () => {} },
 							{ label: "Second", icon: "two", handler: () => {} },
 						]}
 						className="test-class"
-						AnchorComponent={TestAnchor}
-					/>
+					>
+						<TestAnchor />
+					</DropMenu>
 				</Provider>,
 				"when mounted",
 				"with event",
 				{ type: "click", target: "#testAnchor" },
 				"to satisfy",
 				<Wrapper>
-					<TestAnchor id="testAnchor" open menuLabel="TestLabel" />
+					<AnchorWrapper id="testAnchor" open>
+						<TestAnchor open />
+					</AnchorWrapper>
 					<Drawer in>
 						<List id="testDropdown">
 							<Item>
@@ -216,14 +224,14 @@ describe("DropMenu", () => {
 					>
 						<DropMenu
 							id="test"
-							menuLabel="TestLabel"
 							menuItems={[
 								{ label: "First", icon: "one", handler: () => {} },
 								{ label: "Second", icon: "two", handler: () => {} },
 							]}
 							className="test-class"
-							AnchorComponent={TestAnchor}
-						/>
+						>
+							<TestAnchor />
+						</DropMenu>
 					</Provider>
 				</div>,
 				menuNode,
@@ -243,7 +251,7 @@ describe("DropMenu", () => {
 				act(() => {
 					outside.click();
 				});
-				expect(menu, "to contain", <TestAnchor id="testAnchor" menuLabel="TestLabel" />);
+				expect(menu, "to contain", <TestAnchor />);
 				act(() => {
 					clock.tick(1000); // Wait for the menu to unrender
 				});
@@ -264,13 +272,14 @@ describe("DropMenu", () => {
 		const MakeMenu = ({ num }) => (
 			<DropMenu
 				id={"menu" + num}
-				menuLabel={"TestLabel " + num}
 				menuItems={[
 					{ label: "First", icon: "one", handler: () => {} },
 					{ label: "Second", icon: "two", handler: () => {} },
 				]}
 				className={"test-class-" + num}
-			/>
+			>
+				{"TestLabel " + num}
+			</DropMenu>
 		);
 
 		it("renders the anchors", () =>
@@ -283,16 +292,10 @@ describe("DropMenu", () => {
 				"to satisfy",
 				<div>
 					<Wrapper className="test-class-1">
-						<Header>
-							TestLabel 1
-							<Indicator />
-						</Header>
+						<AnchorWrapper>TestLabel 1</AnchorWrapper>
 					</Wrapper>
 					<Wrapper className="test-class-2">
-						<Header>
-							TestLabel 2
-							<Indicator />
-						</Header>
+						<AnchorWrapper>TestLabel 2</AnchorWrapper>
 					</Wrapper>
 				</div>,
 			));
@@ -319,16 +322,10 @@ describe("DropMenu", () => {
 				"to satisfy",
 				<div>
 					<Wrapper className="test-class-1">
-						<Header>
-							TestLabel 1
-							<Indicator />
-						</Header>
+						<AnchorWrapper>TestLabel 1</AnchorWrapper>
 					</Wrapper>
 					<Wrapper className="test-class-2">
-						<Header>
-							TestLabel 2
-							<Indicator />
-						</Header>
+						<AnchorWrapper>TestLabel 2</AnchorWrapper>
 					</Wrapper>
 				</div>,
 			);
@@ -340,16 +337,10 @@ describe("DropMenu", () => {
 				"to satisfy",
 				<div>
 					<Wrapper className="test-class-1">
-						<Header>
-							TestLabel 1
-							<Indicator />
-						</Header>
+						<AnchorWrapper>TestLabel 1</AnchorWrapper>
 					</Wrapper>
 					<Wrapper className="test-class-2">
-						<Header open>
-							TestLabel 2
-							<Indicator open={true} />
-						</Header>
+						<AnchorWrapper open>TestLabel 2</AnchorWrapper>
 						<Drawer in>
 							<List>
 								<Item>
@@ -376,10 +367,7 @@ describe("DropMenu", () => {
 				"to satisfy",
 				<div>
 					<Wrapper className="test-class-1">
-						<Header open>
-							TestLabel 1
-							<Indicator open={true} />
-						</Header>
+						<AnchorWrapper open>TestLabel 1</AnchorWrapper>
 						<Drawer in>
 							<List>
 								<Item>
@@ -394,10 +382,7 @@ describe("DropMenu", () => {
 						</Drawer>
 					</Wrapper>
 					<Wrapper className="test-class-2">
-						<Header>
-							TestLabel 2
-							<Indicator />
-						</Header>
+						<AnchorWrapper>TestLabel 2</AnchorWrapper>
 					</Wrapper>
 				</div>,
 			);

--- a/src/components/DropMenu/DropMenu.test.js
+++ b/src/components/DropMenu/DropMenu.test.js
@@ -7,8 +7,8 @@ import DropMenu, { AnchorWrapper, Wrapper } from "./index";
 import Menu, { Drawer, List, Item, ItemIcon } from "./Menu";
 import { getStyledClassSelector } from "../../utils/testUtils";
 
-const TestAnchor = ({ id, onClick, className, open }) => (
-	<div id={id} onClick={onClick} className={className} data-open={open}>
+const TestAnchor = ({ id, open }) => (
+	<div id={id} data-open={open}>
 		Test anchor
 	</div>
 );
@@ -152,7 +152,7 @@ describe("DropMenu", () => {
 				"to satisfy",
 				<Wrapper className="test-class">
 					<AnchorWrapper id="testAnchor">
-						<TestAnchor />
+						<TestAnchor open={false} />
 					</AnchorWrapper>
 					<Menu id="testDropdown" menuItems={[]} />
 				</Wrapper>,

--- a/src/components/DropMenu/index.js
+++ b/src/components/DropMenu/index.js
@@ -25,7 +25,7 @@ const DropMenu = ({ id, initOpen, menuItems, alignRight, className = "", childre
 		<Wrapper className={className} onClickOutside={reset}>
 			<AnchorWrapper id={id + "Anchor"} onClick={toggle} open={open}>
 				{React.Children.map(children, child =>
-					typeof child === "object" ? React.cloneElement(child, { open: true }) : child,
+					typeof child === "object" ? React.cloneElement(child, { open }) : child,
 				)}
 			</AnchorWrapper>
 			<Menu

--- a/src/components/DropMenu/index.js
+++ b/src/components/DropMenu/index.js
@@ -1,6 +1,5 @@
 import React from "react";
 import styled from "styled-components";
-import Anchor from "./Anchor";
 import Menu from "./Menu";
 import useToggle from "../../hooks/useToggle";
 import withClickOutside from "../../hocs/withClickOutside";
@@ -8,6 +7,8 @@ import withClickOutside from "../../hocs/withClickOutside";
 export const Wrapper = withClickOutside(styled.div`
 	position: relative;
 `);
+
+export const AnchorWrapper = styled.div``;
 
 export const Background = styled.div`
 	position: absolute;
@@ -18,19 +19,15 @@ export const Background = styled.div`
 	z-index: 19998;
 `;
 
-const DropMenu = ({
-	id,
-	initOpen,
-	menuLabel,
-	menuItems,
-	alignRight,
-	className = "",
-	AnchorComponent = Anchor,
-}) => {
+const DropMenu = ({ id, initOpen, menuItems, alignRight, className = "", children }) => {
 	const [open, toggle, reset] = useToggle(initOpen);
 	return (
 		<Wrapper className={className} onClickOutside={reset}>
-			<AnchorComponent id={id + "Anchor"} onClick={toggle} {...{ menuLabel, open }} />
+			<AnchorWrapper id={id + "Anchor"} onClick={toggle} open={open}>
+				{React.Children.map(children, child =>
+					typeof child === "object" ? React.cloneElement(child, { open: true }) : child,
+				)}
+			</AnchorWrapper>
 			<Menu
 				id={id + "Dropdown"}
 				{...{ open, menuItems, reset }}

--- a/src/components/Navigation/Bar.js
+++ b/src/components/Navigation/Bar.js
@@ -203,11 +203,9 @@ const Bar = ({ module, pages }) => {
 				)}
 			</ScrollableBar>
 			{hiddenTabs ? (
-				<StyledMenu
-					id="navigationTabs"
-					menuItems={tabMenuItems}
-					AnchorComponent={MenuButton}
-				/>
+				<StyledMenu id="navigationTabs" menuItems={tabMenuItems}>
+					<MenuButton />
+				</StyledMenu>
 			) : null}
 		</TabBar>
 	);

--- a/src/components/Navigation/Bar.test.js
+++ b/src/components/Navigation/Bar.test.js
@@ -308,8 +308,9 @@ describe("Bar", () => {
 									{ label: "Page 3", id: "/Foo/modu/3" },
 									{ label: "Page 4", id: "/Foo/modu/4" },
 								]}
-								AnchorComponent={MenuButton}
-							/>
+							>
+								<MenuButton />
+							</StyledMenu>
 						</TabBar>
 					</MemoryRouter>
 				</Provider>,


### PR DESCRIPTION
As the Anchor class that was the default anchor component for DropMenu was only used in AppFrame, I separated the two. The Anchor component was moved to AppFrame, while DropMenu will now add menus to its child components.