### PR TITLE
Changed how languages options should be handled in preferences.

### DIFF
--- a/docs/actionsreducersselectors.md
+++ b/docs/actionsreducersselectors.md
@@ -61,7 +61,7 @@ Stores authentication data for the logged-in user, including name and upn, and r
 
 ## `localeFactory(supportedLocales)`
 
-- `supportedLocales`: An array of IETF language tags, designating which locales are to be supported.
+- `supportedLocales`: An array of object containing supported languages and their corresponding IETF language tags, designating which languages and locales are to be supported.
 
 Usually not used directly, as it is included in state stores created with `buildState`. This factory creates a locale reducer from a list of supported locales. This reducer will initially set the selected locale to the first supported locale, and accepts actions to set it to any other. Actions to set unsupported locales will be ignored. This reducer will also store culture (i.e. customer-facing locale) info, and expects to get this data as an array of objects, each containing a `cultureIso` field with the IETF tag of the culture.
 

--- a/package.json
+++ b/package.json
@@ -36,10 +36,10 @@
 	},
 	"homepage": "https://github.com/Orckestra/orc-shared#readme",
 	"devDependencies": {
-		"orc-scripts": "1.0.0-dev.5"
+		"orc-scripts": "1.0.0-dev.6"
 	},
 	"peerDependencies": {
-		"orc-scripts": "^1.0.0-dev.5"
+		"orc-scripts": "^1.0.0-dev.6"
 	},
 	"sideEffects": false,
 	"lint-staged": {

--- a/src/buildStore.js
+++ b/src/buildStore.js
@@ -42,7 +42,9 @@ const buildStore = (reducers, devOptions = {}) => {
 		applyMiddleware(routerMiddleware(history), apiMiddleware, spawnerMiddleware),
 	);
 
-	const supportedLocales = SUPPORTED_LOCALES || ["en"];
+	const supportedLocales = SUPPORTED_LOCALES || [
+		{ language: "English", cultureIso: "en-US" },
+	];
 	const localeReducer = localeFactory(supportedLocales);
 
 	buildReducer = reducers =>

--- a/src/buildStore.test.js
+++ b/src/buildStore.test.js
@@ -43,7 +43,10 @@ describe("buildStore", () => {
 	describe("functionality", () => {
 		let store;
 		beforeEach(() => {
-			global.SUPPORTED_LOCALES = ["en-US", "fr"];
+			global.SUPPORTED_LOCALES = [
+				{ language: "English", cultureIso: "en-US" },
+				{ language: "Francais", cultureIso: "fr" },
+			];
 			store = buildStore(mockReducers);
 		});
 
@@ -71,7 +74,10 @@ describe("buildStore", () => {
 						},
 						locale: {
 							locale: "en-US",
-							supportedLocales: ["en-US", "fr"],
+							supportedLocales: [
+								{ language: "English", cultureIso: "en-US" },
+								{ language: "Francais", cultureIso: "fr" },
+							],
 						},
 						navigation: {
 							tabIndex: {},

--- a/src/components/AppFrame/AppFrame.test.js
+++ b/src/components/AppFrame/AppFrame.test.js
@@ -118,7 +118,8 @@ describe("AppFrame", () => {
 				},
 			},
 			locale: {
-				suportedLocales: [],
+				locale: "en",
+				supportedLocales: [],
 				cultures: {
 					"en-US": {
 						cultureIso: "en-US",

--- a/src/components/AppFrame/Preferences.js
+++ b/src/components/AppFrame/Preferences.js
@@ -13,7 +13,7 @@ import { setDefaultLanguage } from "../../actions/locale";
 import { setMyApplication } from "../../actions/applications";
 import { changeLocale } from "../../actions/locale";
 import { localizedAppOptionSelector } from "../../selectors/applications";
-import { currentLocale, orderedCultureOptionList } from "../../selectors/locale";
+import { currentLocale, cultureOptionList } from "../../selectors/locale";
 import { defaultAppId } from "../../selectors/settings";
 
 export const PREFS_NAME = "__prefsDialog";
@@ -74,6 +74,7 @@ export const createGetUpdater = memoize(update =>
 const usePreferenceSetup = () => {
 	const dispatch = useDispatch();
 	const [viewState, updateViewState] = useViewState(PREFS_NAME);
+
 	return {
 		show: viewState.show,
 		values: {
@@ -82,7 +83,7 @@ const usePreferenceSetup = () => {
 			...viewState,
 		},
 		getUpdater: createGetUpdater(updateViewState),
-		languageOptions: unwrapImmutable(useSelector(orderedCultureOptionList)),
+		languageOptions: unwrapImmutable(useSelector(cultureOptionList)),
 		applicationOptions: unwrapImmutable(useSelector(localizedAppOptionSelector)),
 		clear: () => dispatch(setValue(PREFS_NAME, { show: false })),
 		save: () => {

--- a/src/components/AppFrame/Preferences.test.js
+++ b/src/components/AppFrame/Preferences.test.js
@@ -51,7 +51,12 @@ describe("Preferences", () => {
 			view: { [PREFS_NAME]: { show: true } },
 			locale: {
 				locale: "en-US",
-				supportedLocales: ["en-US", "en-CA", "fr-FR", "fr-CA"],
+				supportedLocales: [
+					{ language: "English", cultureIso: "en-US" },
+					{ language: "EnglishCa", cultureIso: "en-CA" },
+					{ language: "Francais", cultureIso: "fr-FR" },
+					{ language: "Francais-Qc", cultureIso: "fr-CA" },
+				],
 				cultures: {
 					"en-US": {
 						cultureIso: "en-US",
@@ -173,10 +178,10 @@ describe("Preferences", () => {
 									<Label id="language_label">Display language</Label>
 									<SelectorWrapper>
 										<select id="language" value="en-US" onChange={() => {}}>
-											<option>French - France</option>
-											<option>English - United States</option>
-											<option>English - Canada</option>
-											<option>French - Canada</option>
+											<option>English</option>
+											<option>EnglishCa</option>
+											<option>Francais</option>
+											<option>Francais-Qc</option>
 										</select>
 										<Ignore />
 										<Ignore />
@@ -245,10 +250,10 @@ describe("Preferences", () => {
 									<Label id="language_label">Display language</Label>
 									<SelectorWrapper>
 										<select id="language" value="fr-CA" onChange={() => {}}>
-											<option>French - France</option>
-											<option>English - United States</option>
-											<option>English - Canada</option>
-											<option>French - Canada</option>
+											<option>English</option>
+											<option>EnglishCa</option>
+											<option>Francais</option>
+											<option>Francais-Qc</option>
 										</select>
 										<Ignore />
 										<Ignore />
@@ -357,10 +362,10 @@ describe("Preferences", () => {
 									<Label id="language_label">Display language</Label>
 									<SelectorWrapper>
 										<select id="language" value="en-US" onChange={() => {}}>
-											<option>French - France</option>
-											<option>English - United States</option>
-											<option>English - Canada</option>
-											<option>French - Canada</option>
+											<option>English</option>
+											<option>EnglishCa</option>
+											<option>Francais</option>
+											<option>Francais-Qc</option>
 										</select>
 										<Ignore />
 										<Ignore />
@@ -451,10 +456,10 @@ describe("Preferences", () => {
 									<Label id="language_label">Display language</Label>
 									<SelectorWrapper>
 										<select id="language" value="fr-CA" onChange={() => {}}>
-											<option>French - France</option>
-											<option>English - United States</option>
-											<option>English - Canada</option>
-											<option>French - Canada</option>
+											<option>English</option>
+											<option>EnglishCa</option>
+											<option>Francais</option>
+											<option>Francais-Qc</option>
 										</select>
 										<Ignore />
 										<Ignore />
@@ -517,10 +522,10 @@ describe("Preferences", () => {
 								<Label id="language_label">Display language</Label>
 								<SelectorWrapper>
 									<select id="language" value="" onChange={() => {}}>
-										<option>English - United States</option>
-										<option>English - Canada</option>
-										<option>French - France</option>
-										<option>French - Canada</option>
+										<option>English</option>
+										<option>EnglishCa</option>
+										<option>Francais</option>
+										<option>Francais-Qc</option>
 									</select>
 									<Ignore />
 									<Ignore />

--- a/src/components/Provision.test.js
+++ b/src/components/Provision.test.js
@@ -10,7 +10,9 @@ const fakeStore = {
 	dispatch: action => action,
 	getState: () =>
 		Immutable.fromJS({
-			locale: {},
+			locale: {
+				locale: "en",
+			},
 			authentication: {
 				name: "foo@bar.com",
 			},

--- a/src/reducers/localeFactory.js
+++ b/src/reducers/localeFactory.js
@@ -2,17 +2,20 @@ import Immutable from "immutable";
 import { CHANGE_LOCALE, GET_CULTURES_SUCCESS } from "../actions/locale";
 
 const localeFactory = supportedLocales => {
+	const defaultCulture =
+		(supportedLocales[0] && supportedLocales[0].cultureIso) || "en-US";
+
 	const initialState = Immutable.fromJS({
-		locale: supportedLocales[0],
+		locale: defaultCulture,
 		supportedLocales,
 		cultures: {},
-		defaultCulture: supportedLocales[0],
+		defaultCulture: defaultCulture,
 	});
 
 	const locale = (state = initialState, action) => {
 		switch (action.type) {
 			case CHANGE_LOCALE:
-				if (supportedLocales.indexOf(action.payload) !== -1) {
+				if (supportedLocales.findIndex(l => l.cultureIso === action.payload) !== -1) {
 					return state.set("locale", action.payload);
 				} else {
 					return state;

--- a/src/reducers/localeFactory.test.js
+++ b/src/reducers/localeFactory.test.js
@@ -7,11 +7,47 @@ describe("locale reducer factory", () => {
 		expect(
 			reducerFactory,
 			"when called with",
-			[["en-US", "fr"]],
+			[
+				[
+					{ language: "English", cultureIso: "en-US" },
+					{ language: "Francais", cultureIso: "fr" },
+				],
+			],
 			"to be a reducer with initial state",
 			{
 				locale: "en-US",
-				supportedLocales: ["en-US", "fr"],
+				supportedLocales: [
+					{ language: "English", cultureIso: "en-US" },
+					{ language: "Francais", cultureIso: "fr" },
+				],
+				cultures: {},
+				defaultCulture: "en-US",
+			},
+		));
+
+	it("falls back to default value after when creating the reducer", () =>
+		expect(
+			reducerFactory,
+			"when called with",
+			[[]],
+			"to be a reducer with initial state",
+			{
+				locale: "en-US",
+				supportedLocales: [],
+				cultures: {},
+				defaultCulture: "en-US",
+			},
+		));
+
+	it("falls back to default value after when creating the reducer with undefined cultureIso", () =>
+		expect(
+			reducerFactory,
+			"when called with",
+			[[{ language: "English" }]],
+			"to be a reducer with initial state",
+			{
+				locale: "en-US",
+				supportedLocales: [{ language: "English" }],
 				cultures: {},
 				defaultCulture: "en-US",
 			},
@@ -20,13 +56,19 @@ describe("locale reducer factory", () => {
 	describe("created reducer", () => {
 		let reducer;
 		beforeEach(() => {
-			reducer = reducerFactory(["en-US", "fr"]);
+			reducer = reducerFactory([
+				{ language: "English", cultureIso: "en-US" },
+				{ language: "Francais", cultureIso: "fr" },
+			]);
 		});
 
 		it("reacts to locale change by updating to the requested locale", () => {
 			const oldState = Immutable.Map({
 				locale: "en-US",
-				supportedLocales: ["en-US", "fr"],
+				supportedLocales: [
+					{ language: "English", cultureIso: "en-US" },
+					{ language: "Francais", cultureIso: "fr" },
+				],
 				cultures: {},
 				defaultCulture: "en-US",
 			});
@@ -40,7 +82,10 @@ describe("locale reducer factory", () => {
 		it("does not update the locale if the requested language is not supported", () => {
 			const oldState = Immutable.Map({
 				locale: "en-US",
-				supportedLocales: ["en-US", "fr"],
+				supportedLocales: [
+					{ language: "English", cultureIso: "en-US" },
+					{ language: "Francais", cultureIso: "fr" },
+				],
 				cultures: {},
 				defaultCulture: "en-US",
 			});
@@ -54,7 +99,10 @@ describe("locale reducer factory", () => {
 		it("adds cultures fetched from API", () => {
 			const oldState = Immutable.Map({
 				locale: "en-US",
-				supportedLocales: ["en-US", "fr"],
+				supportedLocales: [
+					{ language: "English", cultureIso: "en-US" },
+					{ language: "Francais", cultureIso: "fr" },
+				],
 				cultures: {},
 				defaultCulture: "en-US",
 			});

--- a/src/selectors/locale.js
+++ b/src/selectors/locale.js
@@ -5,7 +5,7 @@ const localeData = state => state.get("locale");
 
 export const defaultLocale = createSelector(
 	localeData,
-	data => data.getIn(["supportedLocales", 0, "cultureIso"]) || "en",
+	data => data.getIn(["supportedLocales", 0, "cultureIso"]) || "en-US",
 );
 
 const supportedLocales = createSelector(

--- a/src/selectors/locale.js
+++ b/src/selectors/locale.js
@@ -1,10 +1,16 @@
+import Immutable from "immutable";
 import { createSelector } from "reselect";
 
 const localeData = state => state.get("locale");
 
 export const defaultLocale = createSelector(
 	localeData,
-	data => data.getIn(["supportedLocales", 0]) || "en",
+	data => data.getIn(["supportedLocales", 0, "cultureIso"]) || "en",
+);
+
+const supportedLocales = createSelector(
+	localeData,
+	data => data.getIn(["supportedLocales"]) || Immutable.fromJS([]),
 );
 
 export const currentLocale = createSelector(
@@ -32,12 +38,9 @@ export const orderedCultureList = createSelector(
 		}),
 );
 
-export const orderedCultureOptionList = createSelector(
-	orderedCultureList,
-	cultures,
-	(list, cultures) =>
-		list.map(iso => ({
-			value: iso,
-			label: cultures.getIn([iso, "cultureName"]),
-		})),
+export const cultureOptionList = createSelector(supportedLocales, locales =>
+	locales.map(iso => ({
+		value: iso.get("cultureIso"),
+		label: iso.get("language"),
+	})),
 );

--- a/src/selectors/locale.test.js
+++ b/src/selectors/locale.test.js
@@ -27,7 +27,7 @@ describe("default locale selector", () => {
 
 	it("returns 'en' if no supported locales", () => {
 		state = state.deleteIn(["locale", "supportedLocales"]);
-		return expect(defaultLocale, "when called with", [state], "to equal", "en");
+		return expect(defaultLocale, "when called with", [state], "to equal", "en-US");
 	});
 });
 
@@ -47,7 +47,7 @@ describe("locale selector", () => {
 
 	it("gets first supported locale if none set", () => {
 		state = state.deleteIn(["locale", "locale"]);
-		return expect(currentLocale, "when called with", [state], "to equal", "en");
+		return expect(currentLocale, "when called with", [state], "to equal", "en-US");
 	});
 });
 

--- a/src/selectors/locale.test.js
+++ b/src/selectors/locale.test.js
@@ -6,7 +6,7 @@ import {
 	cultureList,
 	defaultCulture,
 	orderedCultureList,
-	orderedCultureOptionList,
+	cultureOptionList,
 } from "./locale";
 
 describe("default locale selector", () => {
@@ -14,8 +14,10 @@ describe("default locale selector", () => {
 	beforeEach(() => {
 		state = Immutable.fromJS({
 			locale: {
-				locale: "fr",
-				supportedLocales: ["en", "fr"],
+				supportedLocales: [
+					{ language: "English", cultureIso: "en" },
+					{ language: "Français", cultureIso: "fr" },
+				],
 			},
 		});
 	});
@@ -194,53 +196,35 @@ describe("orderedCultureList", () => {
 		));
 });
 
-describe("orderedCultureOptionList", () => {
+describe("cultureOptionList", () => {
 	let state;
 	beforeEach(() => {
 		state = Immutable.fromJS({
 			locale: {
-				cultures: {
-					"en-US": {
-						cultureIso: "en-US",
-						cultureName: "English - United States",
-						sortOrder: 0,
-						isDefault: false,
-					},
-					"en-CA": {
-						cultureIso: "en-CA",
-						cultureName: "English - Canada",
-						sortOrder: 0,
-						isDefault: false,
-					},
-					"fr-FR": {
-						cultureIso: "fr-FR",
-						cultureName: "French - France",
-						sortOrder: 0,
-						isDefault: true,
-					},
-					"fr-CA": {
-						cultureIso: "fr-CA",
-						cultureName: "French - Canada",
-						sortOrder: 0,
-						isDefault: false,
-					},
-				},
-				defaultCulture: "fr-FR",
+				supportedLocales: [
+					{ language: "English", cultureIso: "en" },
+					{ language: "Français", cultureIso: "fr" },
+					{ language: "Italiano", cultureIso: "it" },
+				],
 			},
 		});
 	});
 
 	it("returns a list of label/value pairs with the default culture first", () =>
 		expect(
-			orderedCultureOptionList,
+			cultureOptionList,
 			"called with",
 			[state],
 			"to satisfy",
 			Immutable.List([
-				{ value: "fr-FR", label: "French - France" },
-				{ value: "en-US", label: "English - United States" },
-				{ value: "en-CA", label: "English - Canada" },
-				{ value: "fr-CA", label: "French - Canada" },
+				{ value: "en", label: "English" },
+				{ value: "fr", label: "Français" },
+				{ value: "it", label: "Italiano" },
 			]),
 		));
+
+	it("returns empty list if there is no locales supported", () => {
+		state = state.deleteIn(["locale", "supportedLocales"]);
+		expect(cultureOptionList, "called with", [state], "to satisfy", Immutable.List([]));
+	});
 });


### PR DESCRIPTION
Languages options in Preference panel should be limited to those three choices only down below as per product owner requirements. The request to fetch supported cultures has other purposes completely and should not be used in preferences.

- English
- Français
- Italiano

"locales" in package.json should be built this way so user may switch from one language to another.

```
"locales": [
    {"language": "English", "cultureIso": "en-US"},
    {"language": "Français", "cultureIso": "fr-CA"},
    {"language": "Italiano", "cultureIso": "it-IT"}
]

```
