### PR TITLE
Corrected DataCell $Nan value to be $0.00

### DIFF
--- a/src/components/List/DataCell.js
+++ b/src/components/List/DataCell.js
@@ -24,7 +24,7 @@ const renderByType = (value, def, rowId, selected, row) => {
 				<FormattedNumber
 					style="currency" // eslint-disable-line react/style-prop-object
 					currency={currency}
-					value={transformedValue}
+					value={transformedValue || "0"}
 				/>
 			);
 		}

--- a/src/components/List/DataCell.test.js
+++ b/src/components/List/DataCell.test.js
@@ -118,6 +118,31 @@ describe("DataCell", () => {
 		);
 	});
 
+	it("renders a cell with type currency for 0", () => {
+		const columnDef = { fieldName: "test", type: "currency", currency: "USD" };
+		const row = { test: "0", extraneous: "Don't show" };
+		return expect(
+			<IntlProvider locale="en">
+				<table>
+					<tbody>
+						<tr>
+							<DataCell columnDef={columnDef} row={row} />
+						</tr>
+					</tbody>
+				</table>
+			</IntlProvider>,
+			"when mounted",
+			"to satisfy",
+			<table>
+				<tbody>
+					<tr>
+						<TableData>$0.00</TableData>
+					</tr>
+				</tbody>
+			</table>,
+		);
+	});
+
 	it("renders a cell with type currency and row-based currency code", () => {
 		const columnDef = {
 			fieldName: "test",


### PR DESCRIPTION
Story #37570

The react-intl FormattedNumber requires a 0 value to be passed in as a "0".
Corrected DataCell to do this conversion.