### PR TITLE
Correct icon and flex wrap of icon for DatePicker

### DIFF
--- a/src/components/Form/Inputs/Date.js
+++ b/src/components/Form/Inputs/Date.js
@@ -2,6 +2,7 @@ import React from "react";
 import DatePicker from "../../MaterialUI/Inputs/DatePicker";
 
 // Component is replaced with DatePicker
+console.warn("Date has been deprecated. Use DatePicker from MaterialUI.");
 
 export const DateInput = ({ update, value, ...props }) => {
 	return <DatePicker {...props} value={value} onChange={update} useTime={false} />;

--- a/src/components/MaterialUI/Inputs/DatePicker.js
+++ b/src/components/MaterialUI/Inputs/DatePicker.js
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
-import { getThemeProp } from "../../../../utils";
-import Icon from "../../../../components/Icon";
+import { getThemeProp } from "../../../utils";
+import Icon from "../../Icon";
 import DatePicker from "react-datepicker";
 import "react-datepicker/dist/react-datepicker.css";
 import TimePicker from "./TimePicker";
@@ -19,7 +19,7 @@ const useStyles = makeStyles(theme => ({
 		},
 		"& .react-datepicker__input-container input": {
 			width: theme.spacing(13.5),
-			border: `1px solid ${getThemeProp(["colors", "borderLight"], "#cccccc")}`,
+			border: `1px solid ${theme.palette.grey.borders}`,
 			zIndex: 100,
 		},
 	},

--- a/src/components/MaterialUI/Inputs/DatePicker.test.js
+++ b/src/components/MaterialUI/Inputs/DatePicker.test.js
@@ -1,6 +1,6 @@
 import React from "react";
 import { IntlProvider } from "react-intl";
-import DatePicker from "./index";
+import DatePicker from "./DatePicker";
 import { Ignore } from "unexpected-reaction";
 import { mount } from "enzyme";
 import sinon from "sinon";

--- a/src/components/MaterialUI/Inputs/DatePicker/index.js
+++ b/src/components/MaterialUI/Inputs/DatePicker/index.js
@@ -9,7 +9,6 @@ import { makeStyles } from "@material-ui/core/styles";
 const useStyles = makeStyles(theme => ({
 	datePickerWrapper: {
 		display: "flex",
-		flexWrap: "wrap",
 		width: "auto",
 		paddingLeft: theme.spacing(0.5),
 		"& .react-datepicker": {
@@ -54,7 +53,7 @@ const WrappedDatePicker = ({ value, useTime, onChange, dateFormat, showTimeZone,
 				customTimeInput={useTime ? <TimePicker showTimeZone={showTimeZone} /> : null}
 				timeInputLabel={timeInputLabel ?? ""}
 			/>
-			<Icon className={classes.calendarIcon} id={getThemeProp(["icons", "date"], "calendar")(props)} />
+			<Icon className={classes.calendarIcon} id={getThemeProp(["icons", "calendar"], "date")(props)} />
 		</label>
 	);
 };

--- a/src/components/MaterialUI/Inputs/TimePicker.js
+++ b/src/components/MaterialUI/Inputs/TimePicker.js
@@ -154,7 +154,8 @@ const TimePicker = ({ value, onChange, showTimeZone, showAMPM }) => {
 							{option.label}
 						</option>
 					))}
-				</select> :
+				</select>{" "}
+				:
 				<select
 					className={classes.timePickerSegmentWrapper}
 					name="mins"

--- a/src/components/MaterialUI/Inputs/TimePicker.test.js
+++ b/src/components/MaterialUI/Inputs/TimePicker.test.js
@@ -6,7 +6,6 @@ import { mount } from "enzyme";
 import sinon from "sinon";
 
 const BuildHours = ({ hours, showAMPM }) => {
-	console.warn("BuildHours", hours, showAMPM);
 	if (showAMPM) {
 		return (
 			<select value={hours} onChange={() => {}}>


### PR DESCRIPTION
In tight spaces, the calendar icon was wrapping below the date, fixed.
The calendar icon naming was wrong, corrected.
Flattened the DatePicker structure (no folder), index renamed.
Corrected incorrect usage of getTheme.
