### PR TITLE
Modification indication for New entity tab

### DIFF
--- a/src/components/MaterialUI/Navigation/TabBar.js
+++ b/src/components/MaterialUI/Navigation/TabBar.js
@@ -1,8 +1,8 @@
 import React from "react";
-import Tabs from '@material-ui/core/Tabs';
+import Tabs from "@material-ui/core/Tabs";
 import TabLabel from "./TabLabel";
-import { makeStyles } from '@material-ui/core/styles';
-import Tab from '@material-ui/core/Tab';
+import { makeStyles } from "@material-ui/core/styles";
+import Tab from "@material-ui/core/Tab";
 import { Link } from "react-router-dom";
 import Select from "../Inputs/Select";
 import SelectProps from "../Inputs/SelectProps";
@@ -14,222 +14,219 @@ import { getModifiedTabs } from "./../../../selectors/view";
 import { useSelector } from "react-redux";
 import ConfirmationModal from "./../DataDisplay/PredefinedElements/ConfirmationModal";
 import { removeEditNode } from "./../../../actions/view";
-import { getValueFromUrlByKey } from "./../../../utils/urlHelper";
+import { getValueFromUrlByKey, tryGetNewEntityIdKey } from "./../../../utils/urlHelper";
 import { useDispatchWithModulesData } from "./../../../hooks/useDispatchWithModulesData";
 import sharedMessages from "./../../../sharedMessages";
 import { FormattedMessage } from "react-intl";
 
-const useStyles = makeStyles((theme) => ({
-  container: {
-    flex: `0 0 ${theme.spacing(1)}`,
-    maxHeight: 0,
-    padding: `0 0 0 ${theme.spacing(1)}`,
-    margin: `0 ${theme.spacing(20)} 0 0`,
-    display: "flex",
-    alignItems: "flex-end",
-    width: `calc(100% - ${theme.spacing(30)})`,
-  },
-  tab: {
-    flex: "0 0 auto"
-  },
-  tabWrapper: {
-    "& > *:first-child": {
-      order: "1 !important",
-      marginLeft: theme.spacing(1),
-      color: theme.palette.primary.contrastText,
+const useStyles = makeStyles(theme => ({
+	container: {
+		flex: `0 0 ${theme.spacing(1)}`,
+		maxHeight: 0,
+		padding: `0 0 0 ${theme.spacing(1)}`,
+		margin: `0 ${theme.spacing(20)} 0 0`,
+		display: "flex",
+		alignItems: "flex-end",
+		width: `calc(100% - ${theme.spacing(30)})`,
+	},
+	tab: {
+		flex: "0 0 auto",
+	},
+	tabWrapper: {
+		"& > *:first-child": {
+			order: "1 !important",
+			marginLeft: theme.spacing(1),
+			color: theme.palette.primary.contrastText,
 
-      "&:hover": {
-        color: theme.palette.primary.main,
-      }
-    }
-  },
-  hidden: {
-    visibility: "hidden",
-    position: "absolute"
-  },
-  moduleIcon: {
-    width: `${theme.spacing(2.4)} !important`,
-    height: theme.spacing(2.4),
-    color: "inherit"
-  },
-  select: {
-    marginLeft: theme.spacing(2),
-    marginBottom: theme.spacing(1),
-    zIndex: 100
-  },
-  closeIcon: {
-    marginLeft: theme.spacing(1),
-    color: theme.palette.primary.contrastText,
-    "&:hover": {
-      color: theme.palette.primary.main,
-    }
-  },
-  labelContainer: {
-    position: "relative"
-  },
-  asterix: {
-    position: "absolute",
-    top: theme.spacing(-0.5),
-    right: theme.spacing(-0.7)
-  }
+			"&:hover": {
+				color: theme.palette.primary.main,
+			},
+		},
+	},
+	hidden: {
+		visibility: "hidden",
+		position: "absolute",
+	},
+	moduleIcon: {
+		width: `${theme.spacing(2.4)} !important`,
+		height: theme.spacing(2.4),
+		color: "inherit",
+	},
+	select: {
+		marginLeft: theme.spacing(2),
+		marginBottom: theme.spacing(1),
+		zIndex: 100,
+	},
+	closeIcon: {
+		marginLeft: theme.spacing(1),
+		color: theme.palette.primary.contrastText,
+		"&:hover": {
+			color: theme.palette.primary.main,
+		},
+	},
+	labelContainer: {
+		position: "relative",
+	},
+	asterix: {
+		position: "absolute",
+		top: theme.spacing(-0.5),
+		right: theme.spacing(-0.7),
+	},
 }));
 
 export const TabLink = React.forwardRef((props, ref) => {
-  return (
-    <Link to={props.to} {...props} ref={ref}>
-      {props.children}
-      {props.close}
-    </Link>
-  )
+	return (
+		<Link to={props.to} {...props} ref={ref}>
+			{props.children}
+			{props.close}
+		</Link>
+	);
 });
 
 const MuiBar = ({ module, pages }) => {
-  const tabs = React.useRef(null);
-  const classes = useStyles();
-  const history = useHistory();
-  const dispatch = useDispatchWithModulesData();
-  const activePage = pages.findIndex(p => p.active === true);
-  const activeTabIndex = activePage === -1 ? false : activePage;
-  const [showSelect, setShowSelect] = React.useState(false);
-  const [showConfirmationModal, setShowConfirmationModal] = React.useState(false);
-  const [currentCloseData, setCurrentCloseData] = React.useState();
+	const tabs = React.useRef(null);
+	const classes = useStyles();
+	const history = useHistory();
+	const dispatch = useDispatchWithModulesData();
+	const activePage = pages.findIndex(p => p.active === true);
+	const activeTabIndex = activePage === -1 ? false : activePage;
+	const [showSelect, setShowSelect] = React.useState(false);
+	const [showConfirmationModal, setShowConfirmationModal] = React.useState(false);
+	const [currentCloseData, setCurrentCloseData] = React.useState();
 
-  const pagesParams = pages.map(page => (
-    {
-      href: page.href,
-      params: Object.values(page.params)
-    }
-  ));
+	const pagesParams = pages.map(page => ({
+		href: page.href,
+		params: Object.values(page.params),
+	}));
 
-  const modifiedTabs = useSelector(getModifiedTabs(pagesParams));
+	const modifiedTabs = useSelector(getModifiedTabs(pagesParams));
 
-  const handleChange = (_, value) => {
-    if (value === false) {
-      history.push(module.href);
-    }
-    else {
-      const href = pages[value].href;
-      history.push(href)
-    }
-  };
+	const handleChange = (_, value) => {
+		if (value === false) {
+			history.push(module.href);
+		} else {
+			const href = pages[value].href;
+			history.push(href);
+		}
+	};
 
-  const tabLabels = [];
+	const tabLabels = [];
 
-  const selectProps = new SelectProps();
-  selectProps.set(SelectProps.propNames.iconSelect, true);
-  selectProps.set(SelectProps.propNames.value, activeTabIndex === false ? '' : activeTabIndex);
-  selectProps.set(SelectProps.propNames.update, (newValue) => handleChange(null, newValue));
+	const selectProps = new SelectProps();
+	selectProps.set(SelectProps.propNames.iconSelect, true);
+	selectProps.set(SelectProps.propNames.value, activeTabIndex === false ? "" : activeTabIndex);
+	selectProps.set(SelectProps.propNames.update, newValue => handleChange(null, newValue));
 
-  const select = <div className={classes.select}><Select options={tabLabels} selectProps={selectProps} /></div>;
+	const select = (
+		<div className={classes.select}>
+			<Select options={tabLabels} selectProps={selectProps} />
+		</div>
+	);
 
-  const tabCloseHandler = (event, closeCallback, isModified, href, path, entityIdKey) => {
-    event.stopPropagation();
-    event.preventDefault();
-    if (isModified) {
-      setCurrentCloseData({ closeCallback: closeCallback, href: href, path: path, entityIdKey: entityIdKey });
-      setShowConfirmationModal(true);
-    }
-    else {
-      closeCallback();
-    }
-  };
+	const tabCloseHandler = (event, closeCallback, isModified, href, path, entityIdKey) => {
+		event.stopPropagation();
+		event.preventDefault();
+		if (isModified) {
+			setCurrentCloseData({ closeCallback: closeCallback, href: href, path: path, entityIdKey: entityIdKey });
+			setShowConfirmationModal(true);
+		} else {
+			closeCallback();
+		}
+	};
 
-  const closeTab = () => {
-    setShowConfirmationModal(false);
-    currentCloseData.closeCallback();
-    const entityId = getValueFromUrlByKey(currentCloseData.href, currentCloseData.path, `:${currentCloseData.entityIdKey}`);
-    dispatch(removeEditNode, [entityId]);
-  }
+	const closeTab = () => {
+		setShowConfirmationModal(false);
+		currentCloseData.closeCallback();
+		let newKey = tryGetNewEntityIdKey(currentCloseData.href);
+		const key =
+			currentCloseData.entityIdKey === newKey ? currentCloseData.entityIdKey : `:${currentCloseData.entityIdKey}`;
+		const entityId = getValueFromUrlByKey(currentCloseData.href, currentCloseData.path, key);
+		dispatch(removeEditNode, [entityId]);
+	};
 
-  const moduleIcon = <Icon id={module.icon} className={classes.moduleIcon} />
+	const moduleIcon = <Icon id={module.icon} className={classes.moduleIcon} />;
 
-  const resizeHandler = React.useCallback(() => {
-    const scroller = tabs.current.querySelector(".MuiTabs-flexContainer");
-    setShowSelect(isScrollVisible(scroller));
-  }, [tabs]);
+	const resizeHandler = React.useCallback(() => {
+		const scroller = tabs.current.querySelector(".MuiTabs-flexContainer");
+		setShowSelect(isScrollVisible(scroller));
+	}, [tabs]);
 
-  React.useEffect(() => {
-    resizeHandler();
-  }, [resizeHandler, module, pages]);
+	React.useEffect(() => {
+		resizeHandler();
+	}, [resizeHandler, module, pages]);
 
-  return (
-    <div className={classes.container}>
-      <ResizeDetector onResize={resizeHandler} />
-      <Tab
-        label={<TabLabel label={module.label} />}
-        component={Link}
-        key={module.href}
-        to={module.href}
-        icon={moduleIcon}
-        onClick={(e) => handleChange(e, false)}
-        className={activeTabIndex === false ? "Mui-selected" : null}
-        disableFocusRipple
-      />
-      <Tabs
-        value={activeTabIndex}
-        onChange={handleChange}
-        variant="scrollable"
-        scrollButtons="off"
-        classes={{
-          scrollButtons: classes.hidden
-        }}
-        ref={tabs}
-      >
-        {
-          pages.map(
-            ({ href, label, outsideScope, close, path, params }, index) => {
-              const entityIdKey = Object.keys(params).find(p => p !== 'scope');
-              const isModified = modifiedTabs.includes(href);
-              const tabLabel = <TabLabel label={label} />;
-              const wrappedTabLabel = (
-                <div className={classes.labelContainer}>
-                  <TabLabel label={label} />
-                  {
-                    isModified === true ?
-                      <span className={classes.asterix}>*</span> : null
-                  }
-                </div>
-              );
-              const closeIcon = (
-                <Icon
-                  id="close"
-                  className={classes.closeIcon}
-                  onClick={(event) => tabCloseHandler(event, close, isModified, href, path, entityIdKey)}
-                />
-              );
-              tabLabels.push({
-                value: index,
-                label: tabLabel,
-                sortOrder: index
-              });
-              return (
-                <Tab
-                  classes={{
-                    root: classes.tab,
-                  }}
-                  component={TabLink}
-                  label={wrappedTabLabel}
-                  key={href}
-                  to={href}
-                  value={index}
-                  close={closeIcon}
-                  disabled={outsideScope}
-                />
-              )
-            }
-          )
-        }
-      </Tabs>
-      {showSelect ? select : null}
-      <ConfirmationModal
-        message={<FormattedMessage {...sharedMessages.unsavedChanges} />}
-        open={showConfirmationModal}
-        okCallback={() => closeTab()}
-        cancelCallback={() => setShowConfirmationModal(false)}
-        backdropClickCallback={() => setShowConfirmationModal(false)}
-      />
-    </div>
-  );
+	return (
+		<div className={classes.container}>
+			<ResizeDetector onResize={resizeHandler} />
+			<Tab
+				label={<TabLabel label={module.label} />}
+				component={Link}
+				key={module.href}
+				to={module.href}
+				icon={moduleIcon}
+				onClick={e => handleChange(e, false)}
+				className={activeTabIndex === false ? "Mui-selected" : null}
+				disableFocusRipple
+			/>
+			<Tabs
+				value={activeTabIndex}
+				onChange={handleChange}
+				variant="scrollable"
+				scrollButtons="off"
+				classes={{
+					scrollButtons: classes.hidden,
+				}}
+				ref={tabs}
+			>
+				{pages.map(({ href, label, outsideScope, close, path, params }, index) => {
+					let entityIdKey = Object.keys(params).find(p => p !== "scope");
+					if (!entityIdKey) entityIdKey = tryGetNewEntityIdKey(href);
+					const isModified = modifiedTabs.includes(href);
+					const tabLabel = <TabLabel label={label} />;
+					const wrappedTabLabel = (
+						<div className={classes.labelContainer}>
+							<TabLabel label={label} />
+							{isModified === true ? <span className={classes.asterix}>*</span> : null}
+						</div>
+					);
+					const closeIcon = (
+						<Icon
+							id="close"
+							className={classes.closeIcon}
+							onClick={event => tabCloseHandler(event, close, isModified, href, path, entityIdKey)}
+						/>
+					);
+					tabLabels.push({
+						value: index,
+						label: tabLabel,
+						sortOrder: index,
+					});
+					return (
+						<Tab
+							classes={{
+								root: classes.tab,
+							}}
+							component={TabLink}
+							label={wrappedTabLabel}
+							key={href}
+							to={href}
+							value={index}
+							close={closeIcon}
+							disabled={outsideScope}
+						/>
+					);
+				})}
+			</Tabs>
+			{showSelect ? select : null}
+			<ConfirmationModal
+				message={<FormattedMessage {...sharedMessages.unsavedChanges} />}
+				open={showConfirmationModal}
+				okCallback={() => closeTab()}
+				cancelCallback={() => setShowConfirmationModal(false)}
+				backdropClickCallback={() => setShowConfirmationModal(false)}
+			/>
+		</div>
+	);
 };
 
 export default MuiBar;

--- a/src/components/MaterialUI/Navigation/TabBar.test.js
+++ b/src/components/MaterialUI/Navigation/TabBar.test.js
@@ -1,9 +1,9 @@
 import React from "react";
-import { mount } from "enzyme"
+import { mount } from "enzyme";
 import TabBar, { TabLink } from "./TabBar";
-import Tabs from '@material-ui/core/Tabs';
+import Tabs from "@material-ui/core/Tabs";
 import TabLabel from "./TabLabel";
-import Tab from '@material-ui/core/Tab';
+import Tab from "@material-ui/core/Tab";
 import Select from "../Inputs/Select";
 import SelectProps from "../Inputs/SelectProps";
 import Icon from "../DataDisplay/Icon";
@@ -28,537 +28,612 @@ import { stringifyWithoutQuotes } from "./../../../utils/parseHelper";
 const messages = extractMessages(sharedMessages);
 
 describe("TabBar", () => {
-  let store, state;
-  const history = createMemoryHistory({ initialEntries: ["/"] });
-  sinon.spy(history, "push");
-
-  const module = {
-    icon: 'cloud',
-    label: messages.module1,
-    href: '/Scope1/module1',
-    active: true,
-  };
-
-  const pages = [
-    {
-      label: messages.page1,
-      href: '/Scope1/module1/page1',
-      params: { scope: "Scope1", entityId: "page1" },
-      active: false,
-      close: sinon.spy(),
-      path: '/:scope/module1/:entityId'
-    },
-    {
-      label: messages.page2,
-      href: '/Scope1/module1/page2',
-      params: { scope: "Scope1", entityId: "page2" },
-      active: false,
-      close: sinon.spy(),
-      path: '/:scope/module1/:entityId'
-    },
-    {
-      label: messages.page3,
-      href: '/Scope1/module1/page3',
-      params: { scope: "Scope1", entityId: "page3" },
-      active: false,
-      close: sinon.spy(),
-      path: '/:scope/module1/:entityId'
-    },
-  ];
-
-  const closeIcon = <Icon id="close" />;
-
-  const moduleIcon = <Icon id={module.icon} />;
-
-  const moduleTabLabel = <TabLabel label={messages.module1} />;
-  const page1TabLabel = <TabLabel label={messages.page1} />;
-  const page2TabLabel = <TabLabel label={messages.page2} />;
-  const page3TabLabel = <TabLabel label={messages.page3} />;
-
-  const selectProps = new SelectProps();
-  selectProps.set(SelectProps.propNames.iconSelect, true);
-  selectProps.set(SelectProps.propNames.value, '');
-  selectProps.set(SelectProps.propNames.update, jest.fn());
-
-  const tabLabels = [];
-
-  tabLabels.push({
-    value: 0,
-    label: page1TabLabel,
-    sortOrder: 0,
-    outsideScope: false
-  });
-  tabLabels.push({
-    value: 1,
-    label: page2TabLabel,
-    sortOrder: 1,
-    outsideScope: true,
-  });
-  tabLabels.push({
-    value: 2,
-    label: page3TabLabel,
-    sortOrder: 2,
-    outsideScope: false
-  });
-
-  const select = <div><Select options={tabLabels} selectProps={selectProps} /></div>;
-
-  const expectedModuleTab = (
-    <Tab
-      label={moduleTabLabel}
-      key={module.href}
-      to={module.href}
-      icon={moduleIcon}
-      component={TabLink}
-    />
-  );
-
-  const wrappedPage1TabLabel = <div><TabLabel label={messages.page1} /></div>;
-  const wrappedPage2TabLabel = <div><TabLabel label={messages.page2} /></div>;
-  const wrappedPage3TabLabel = (
-    <div>
-      <TabLabel label={messages.page3} />
-      <span>*</span>
-    </div>
-  );
-
-  const expectedTabs = (
-    <Tabs
-      value={false}
-      variant="scrollable"
-      scrollButtons="auto"
-    >
-      <Tab
-        label={wrappedPage1TabLabel}
-        key={pages[0].href}
-        to={pages[0].href}
-        value={0}
-        component={TabLink}
-        close={closeIcon}
-        disabled={pages[0].outsideScope}
-      />
-      <Tab
-        label={wrappedPage2TabLabel}
-        key={pages[1].href}
-        to={pages[1].href}
-        value={1}
-        component={TabLink}
-        close={closeIcon}
-        disabled={pages[1].outsideScope}
-      />
-      <Tab
-        label={wrappedPage3TabLabel}
-        key={pages[2].href}
-        to={pages[2].href}
-        value={2}
-        component={TabLink}
-        close={closeIcon}
-        disabled={pages[2].outsideScope}
-      />
-    </Tabs>
-  );
-
-  beforeEach(() => {
-    state = Immutable.fromJS({
-      modules: {
-        tree: {}
-      },
-      view: {
-        edit: {
-          module1: {
-            page3: {
-              section1: {
-                model: {
-                  field1: {
-                    value: "smth",
-                    wasModified: true
-                  }
-                }
-              }
-            }
-          }
-        }
-      },
-      navigation: {
-        route: {
-          match: {
-            url: "/Scope1/module1/page1",
-            path: "/:scope/module1/page1",
-            params: { scope: "Scope1" },
-          },
-        },
-        config: { prependPath: "/:scope/", prependHref: "/Scope1/" },
-      },
-    });
-    store = {
-      subscribe: () => { },
-      getState: () => state,
-      dispatch: () => { },
-    };
-  });
-
-  it("Renders TabBar correctly", () => {
-    const component = (
-      <Provider store={store}>
-        <MemoryRouter>
-          <IntlProvider locale="en-US" messages={messages}>
-            <TabBar module={module} pages={pages} />
-          </IntlProvider>
-        </MemoryRouter>
-      </Provider>
-    );
-
-    const expected = (
-      <Provider store={store}>
-        <MemoryRouter>
-          <IntlProvider locale="en-US" messages={messages}>
-            <div>
-              <ResizeDetector />
-              {expectedModuleTab}
-              {expectedTabs}
-              <ConfirmationModal
-                message={stringifyWithoutQuotes(messages['orc-shared.unsavedChanges'])}
-                open={false}
-              />
-            </div>
-          </IntlProvider>
-        </MemoryRouter>
-      </Provider>
-    );
-
-    expect(component, "when mounted", "to satisfy", expected);
-  });
-
-  it("Contains proper Select and Modal elements when they are visible", () => {
-    const component = (
-      <Provider store={store}>
-        <MemoryRouter>
-          <IntlProvider locale="en-US" messages={messages}>
-            <TabBar module={module} pages={pages} />
-          </IntlProvider>
-        </MemoryRouter>
-      </Provider>
-    );
-
-    const setState = jest.fn();
-    const useStateSpy = jest.spyOn(React, 'useState')
-    useStateSpy.mockImplementation(() => [true, setState]);
-
-    const expected = (
-      <Provider store={store}>
-        <MemoryRouter>
-          <IntlProvider locale="en-US" messages={messages}>
-            <div>
-              <ResizeDetector />
-              {expectedModuleTab}
-              {expectedTabs}
-              {select}
-              <ConfirmationModal
-                message={stringifyWithoutQuotes(messages['orc-shared.unsavedChanges'])}
-                open={true}
-              />
-            </div>
-          </IntlProvider>
-        </MemoryRouter>
-      </Provider>
-    );
-
-    expect(component, "when mounted", "to satisfy", expected);
-  });
-
-  it("Calls history.push to module link when module tab is clicked", () => {
-    const component = (
-      <Provider store={store}>
-        <Router history={history}>
-          <IntlProvider locale="en-US" messages={messages}>
-            <TabBar module={module} pages={pages} />
-          </IntlProvider>
-        </Router>
-      </Provider>
-    );
-
-    const mountedComponent = mount(component);
-
-    const moduleTab = mountedComponent.find(Tab).at(0);
-
-    moduleTab.simulate("click");
-
-    expect(history.push, "to have a call satisfying", { args: [module.href] });
-  });
-
-  it("Calls history.push to page link when page tab is clicked", () => {
-    const component = (
-      <Provider store={store}>
-        <Router history={history}>
-          <IntlProvider locale="en-US" messages={messages}>
-            <TabBar module={module} pages={pages} />
-          </IntlProvider>
-        </Router>
-      </Provider>
-    );
-
-    const mountedComponent = mount(component);
-
-    const pageTab = mountedComponent.find(Tab).at(1);
-
-    pageTab.simulate("click");
-
-    expect(history.push, "to have a call satisfying", { args: [pages[0].href] });
-  });
-
-  it("Calls history.push to page link when page tab is selected via Select", () => {
-    const component = (
-      <Provider store={store}>
-        <Router history={history}>
-          <IntlProvider locale="en-US" messages={messages}>
-            <TabBar module={module} pages={pages} />
-          </IntlProvider>
-        </Router>
-      </Provider>
-    );
-
-    const setState = jest.fn();
-    const useStateSpy = jest.spyOn(React, 'useState')
-    useStateSpy.mockImplementation(() => [true, setState]);
-
-    const mountedComponent = mount(component);
-
-    const select = mountedComponent.find(SelectMUI);
-
-    select.invoke("onChange")({ target: { value: 2 } });
-
-    expect(history.push, "to have a call satisfying", { args: [pages[2].href] });
-  });
-
-  it("Calls correct close callback when close icon for specific page tab is clicked and tab was not modified", () => {
-    const component = (
-      <Provider store={store}>
-        < MemoryRouter>
-          <IntlProvider locale="en-US" messages={messages}>
-            <TabBar module={module} pages={pages} />
-          </IntlProvider>
-        </MemoryRouter>
-      </Provider>
-    );
-
-    const mountedComponent = mount(component);
-
-    const pageTab = mountedComponent.find(Tab).at(1);
-    const closeIcon = pageTab.find(Icon);
-
-    closeIcon.simulate("click");
-
-    expect(pages[0].close, "was called");
-  });
-
-  it("Calls correct close callback when close icon for specific page tab is clicked and tab was modified", () => {
-    const component = (
-      <Provider store={store}>
-        < MemoryRouter>
-          <IntlProvider locale="en-US" messages={messages}>
-            <TabBar module={module} pages={pages} />
-          </IntlProvider>
-        </MemoryRouter>
-      </Provider>
-    );
-
-    const setState = sinon.spy();
-    const useStateSpy = jest.spyOn(React, 'useState')
-    useStateSpy.mockImplementation((value) => [value, setState]);
-
-    const mountedComponent = mount(component);
-
-    const pageTab = mountedComponent.find(Tab).at(3);
-    const closeIcon = pageTab.find(Icon);
-
-    closeIcon.simulate("click");
-
-    expect(setState, "to have a call satisfying", { args: [{ closeCallback: pages[2].close, href: pages[2].href }] });
-
-    expect(setState, "to have a call satisfying", { args: [true] });
-  });
-
-  it("Handles onResize correct when isScrollVisible returns false", () => {
-    const component = (
-      <Provider store={store}>
-        <MemoryRouter>
-          <IntlProvider locale="en-US" messages={messages}>
-            <TabBar module={module} pages={pages} />
-          </IntlProvider>
-        </MemoryRouter>
-      </Provider>
-    );
-
-    const setState = sinon.spy();
-    const useStateSpy = jest.spyOn(React, 'useState');
-    useStateSpy.mockImplementation((value) => [value, setState]);
-
-    const isScrollVisibleStub = sinon.stub(domHelper, "isScrollVisible").returns(false);
-
-    const mountedComponent = mount(component);
-
-    const resizeDetector = mountedComponent.find(ResizeDetector);
-
-    resizeDetector.invoke("onResize")();
-
-    expect(isScrollVisibleStub.getCall(0).args[0].className, "to equal", "MuiTabs-flexContainer");
-
-    expect(setState, "to have a call satisfying", { args: [false] });
-
-    isScrollVisibleStub.restore();
-    useStateSpy.mockRestore();
-  });
-
-  it("Handles onResize correct when isScrollVisible returns true", () => {
-    const component = (
-      <Provider store={store}>
-        <MemoryRouter>
-          <IntlProvider locale="en-US" messages={messages}>
-            <TabBar module={module} pages={pages} />
-          </IntlProvider>
-        </MemoryRouter>
-      </Provider>
-    );
-
-    const setState = sinon.spy();
-    const useStateSpy = jest.spyOn(React, 'useState')
-    useStateSpy.mockImplementation((value) => [value, setState]);
-
-    const mountedComponent = mount(component);
-
-    const isScrollVisibleStub = sinon.stub(domHelper, "isScrollVisible").returns(true);
-
-    const resizeDetector = mountedComponent.find(ResizeDetector);
-
-    resizeDetector.invoke("onResize")();
-
-    expect(isScrollVisibleStub.getCall(0).args[0].className, "to equal", "MuiTabs-flexContainer");
-
-    expect(setState, "to have a call satisfying", { args: [true] });
-
-    isScrollVisibleStub.restore();
-    useStateSpy.mockRestore();
-  });
-
-  it("Closes tab when ok callback in confirmation modal is triggered", () => {
-    const component = (
-      <Provider store={store}>
-        <MemoryRouter>
-          <IntlProvider locale="en-US" messages={messages}>
-            <TabBar module={module} pages={pages} />
-          </IntlProvider>
-        </MemoryRouter>
-      </Provider>
-    );
-
-    const dispatchSpy = sinon.spy();
-    const useDispatchWithModulesDataStub =
-      sinon.stub(useDispatchWithModulesData, "useDispatchWithModulesData").returns(dispatchSpy);
-
-    const useStateStub = sinon.stub(ReactMock, "useState");
-    useStateStub.withArgs(undefined).returns([
-      { closeCallback: pages[2].close, href: pages[2].href }, jest.fn()
-    ]);
-
-    const mountedComponent = mount(component);
-
-    const pageTab = mountedComponent.find(Tab).at(3);
-    const closeIcon = pageTab.find(Icon);
-
-    closeIcon.simulate("click");
-
-    let confirmationModal = mountedComponent.find(ConfirmationModal);
-
-    confirmationModal.invoke("okCallback")();
-
-    confirmationModal = mountedComponent.find(ConfirmationModal);
-
-    expect(confirmationModal.prop("open"), "to be false");
-    expect(pages[2].close, "was called");
-    expect(dispatchSpy, "to have a call satisfying", { args: [removeEditNode, [pages[2].params.entityId]] });
-
-    useDispatchWithModulesDataStub.restore();
-    useStateStub.restore();
-  });
-
-  it("Closes confirmation modal when cancelCallback is triggered", () => {
-    const component = (
-      <Provider store={store}>
-        <MemoryRouter>
-          <IntlProvider locale="en-US" messages={messages}>
-            <TabBar module={module} pages={pages} />
-          </IntlProvider>
-        </MemoryRouter>
-      </Provider>
-    );
-
-    const mountedComponent = mount(component);
-
-    const pageTab = mountedComponent.find(Tab).at(3);
-    const closeIcon = pageTab.find(Icon);
-
-    closeIcon.simulate("click");
-
-    let confirmationModal = mountedComponent.find(ConfirmationModal);
-
-    confirmationModal.invoke("cancelCallback")();
-
-    confirmationModal = mountedComponent.find(ConfirmationModal);
-
-    expect(confirmationModal.prop("open"), "to be false");
-  });
-
-  it("Closes confirmation modal when backdropClickCallback is triggered", () => {
-    const component = (
-      <Provider store={store}>
-        <MemoryRouter>
-          <IntlProvider locale="en-US" messages={messages}>
-            <TabBar module={module} pages={pages} />
-          </IntlProvider>
-        </MemoryRouter>
-      </Provider>
-    );
-
-    const mountedComponent = mount(component);
-
-    const pageTab = mountedComponent.find(Tab).at(3);
-    const closeIcon = pageTab.find(Icon);
-
-    closeIcon.simulate("click");
-
-    let confirmationModal = mountedComponent.find(ConfirmationModal);
-
-    confirmationModal.invoke("backdropClickCallback")();
-
-    confirmationModal = mountedComponent.find(ConfirmationModal);
-
-    expect(confirmationModal.prop("open"), "to be false");
-  });
+	let store, state;
+	const history = createMemoryHistory({ initialEntries: ["/"] });
+	sinon.spy(history, "push");
+
+	const module = {
+		icon: "cloud",
+		label: messages.module1,
+		href: "/Scope1/module1",
+		active: true,
+	};
+
+	const pages = [
+		{
+			label: messages.page1,
+			href: "/Scope1/module1/page1",
+			params: { scope: "Scope1", entityId: "page1" },
+			active: false,
+			close: sinon.spy(),
+			path: "/:scope/module1/:entityId",
+		},
+		{
+			label: messages.page2,
+			href: "/Scope1/module1/page2",
+			params: { scope: "Scope1", entityId: "page2" },
+			active: false,
+			close: sinon.spy(),
+			path: "/:scope/module1/:entityId",
+		},
+		{
+			label: messages.page3,
+			href: "/Scope1/module1/page3",
+			params: { scope: "Scope1", entityId: "page3" },
+			active: false,
+			close: sinon.spy(),
+			path: "/:scope/module1/:entityId",
+		},
+		{
+			label: messages.pageNew,
+			href: "/Scope1/module1/new",
+			params: { scope: "Scope1" },
+			active: false,
+			close: sinon.spy(),
+			path: "/:scope/module1/new",
+		},
+	];
+
+	const closeIcon = <Icon id="close" />;
+
+	const moduleIcon = <Icon id={module.icon} />;
+
+	const moduleTabLabel = <TabLabel label={messages.module1} />;
+	const page1TabLabel = <TabLabel label={messages.page1} />;
+	const page2TabLabel = <TabLabel label={messages.page2} />;
+	const page3TabLabel = <TabLabel label={messages.page3} />;
+	const pageNewTabLabel = <TabLabel label={messages.pageNew} />;
+
+	const selectProps = new SelectProps();
+	selectProps.set(SelectProps.propNames.iconSelect, true);
+	selectProps.set(SelectProps.propNames.value, "");
+	selectProps.set(SelectProps.propNames.update, jest.fn());
+
+	const tabLabels = [];
+
+	tabLabels.push({
+		value: 0,
+		label: page1TabLabel,
+		sortOrder: 0,
+		outsideScope: false,
+	});
+	tabLabels.push({
+		value: 1,
+		label: page2TabLabel,
+		sortOrder: 1,
+		outsideScope: true,
+	});
+	tabLabels.push({
+		value: 2,
+		label: page3TabLabel,
+		sortOrder: 2,
+		outsideScope: false,
+	});
+	tabLabels.push({
+		value: 3,
+		label: pageNewTabLabel,
+		sortOrder: 3,
+		outsideScope: false,
+	});
+
+	const select = (
+		<div>
+			<Select options={tabLabels} selectProps={selectProps} />
+		</div>
+	);
+
+	const expectedModuleTab = (
+		<Tab label={moduleTabLabel} key={module.href} to={module.href} icon={moduleIcon} component={TabLink} />
+	);
+
+	const wrappedPage1TabLabel = (
+		<div>
+			<TabLabel label={messages.page1} />
+		</div>
+	);
+	const wrappedPage2TabLabel = (
+		<div>
+			<TabLabel label={messages.page2} />
+		</div>
+	);
+	const wrappedPage3TabLabel = (
+		<div>
+			<TabLabel label={messages.page3} />
+			<span>*</span>
+		</div>
+	);
+	const wrappedPageNewTabLabel = (
+		<div>
+			<TabLabel label={messages.pageNew} />
+			<span>*</span>
+		</div>
+	);
+
+	const expectedTabs = (
+		<Tabs value={false} variant="scrollable" scrollButtons="auto">
+			<Tab
+				label={wrappedPage1TabLabel}
+				key={pages[0].href}
+				to={pages[0].href}
+				value={0}
+				component={TabLink}
+				close={closeIcon}
+				disabled={pages[0].outsideScope}
+			/>
+			<Tab
+				label={wrappedPage2TabLabel}
+				key={pages[1].href}
+				to={pages[1].href}
+				value={1}
+				component={TabLink}
+				close={closeIcon}
+				disabled={pages[1].outsideScope}
+			/>
+			<Tab
+				label={wrappedPage3TabLabel}
+				key={pages[2].href}
+				to={pages[2].href}
+				value={2}
+				component={TabLink}
+				close={closeIcon}
+				disabled={pages[2].outsideScope}
+			/>
+			<Tab
+				label={wrappedPageNewTabLabel}
+				key={pages[3].href}
+				to={pages[3].href}
+				value={3}
+				component={TabLink}
+				close={closeIcon}
+				disabled={pages[3].outsideScope}
+			/>
+		</Tabs>
+	);
+
+	beforeEach(() => {
+		state = Immutable.fromJS({
+			modules: {
+				tree: {},
+			},
+			view: {
+				edit: {
+					module1: {
+						page3: {
+							section1: {
+								model: {
+									field1: {
+										value: "smth",
+										wasModified: true,
+									},
+								},
+							},
+						},
+						new: {
+							section1: {
+								model: {
+									field1: {
+										value: "smth",
+										wasModified: true,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			navigation: {
+				route: {
+					match: {
+						url: "/Scope1/module1/page1",
+						path: "/:scope/module1/page1",
+						params: { scope: "Scope1" },
+					},
+				},
+				config: { prependPath: "/:scope/", prependHref: "/Scope1/" },
+			},
+		});
+		store = {
+			subscribe: () => {},
+			getState: () => state,
+			dispatch: () => {},
+		};
+	});
+
+	it("Renders TabBar correctly", () => {
+		const component = (
+			<Provider store={store}>
+				<MemoryRouter>
+					<IntlProvider locale="en-US" messages={messages}>
+						<TabBar module={module} pages={pages} />
+					</IntlProvider>
+				</MemoryRouter>
+			</Provider>
+		);
+
+		const expected = (
+			<Provider store={store}>
+				<MemoryRouter>
+					<IntlProvider locale="en-US" messages={messages}>
+						<div>
+							<ResizeDetector />
+							{expectedModuleTab}
+							{expectedTabs}
+							<ConfirmationModal message={stringifyWithoutQuotes(messages["orc-shared.unsavedChanges"])} open={false} />
+						</div>
+					</IntlProvider>
+				</MemoryRouter>
+			</Provider>
+		);
+
+		expect(component, "when mounted", "to satisfy", expected);
+	});
+
+	it("Contains proper Select and Modal elements when they are visible", () => {
+		const component = (
+			<Provider store={store}>
+				<MemoryRouter>
+					<IntlProvider locale="en-US" messages={messages}>
+						<TabBar module={module} pages={pages} />
+					</IntlProvider>
+				</MemoryRouter>
+			</Provider>
+		);
+
+		const setState = jest.fn();
+		const useStateSpy = jest.spyOn(React, "useState");
+		useStateSpy.mockImplementation(() => [true, setState]);
+
+		const expected = (
+			<Provider store={store}>
+				<MemoryRouter>
+					<IntlProvider locale="en-US" messages={messages}>
+						<div>
+							<ResizeDetector />
+							{expectedModuleTab}
+							{expectedTabs}
+							{select}
+							<ConfirmationModal message={stringifyWithoutQuotes(messages["orc-shared.unsavedChanges"])} open={true} />
+						</div>
+					</IntlProvider>
+				</MemoryRouter>
+			</Provider>
+		);
+
+		expect(component, "when mounted", "to satisfy", expected);
+	});
+
+	it("Calls history.push to module link when module tab is clicked", () => {
+		const component = (
+			<Provider store={store}>
+				<Router history={history}>
+					<IntlProvider locale="en-US" messages={messages}>
+						<TabBar module={module} pages={pages} />
+					</IntlProvider>
+				</Router>
+			</Provider>
+		);
+
+		const mountedComponent = mount(component);
+
+		const moduleTab = mountedComponent.find(Tab).at(0);
+
+		moduleTab.simulate("click");
+
+		expect(history.push, "to have a call satisfying", { args: [module.href] });
+	});
+
+	it("Calls history.push to page link when page tab is clicked", () => {
+		const component = (
+			<Provider store={store}>
+				<Router history={history}>
+					<IntlProvider locale="en-US" messages={messages}>
+						<TabBar module={module} pages={pages} />
+					</IntlProvider>
+				</Router>
+			</Provider>
+		);
+
+		const mountedComponent = mount(component);
+
+		const pageTab = mountedComponent.find(Tab).at(1);
+
+		pageTab.simulate("click");
+
+		expect(history.push, "to have a call satisfying", { args: [pages[0].href] });
+	});
+
+	it("Calls history.push to page link when page tab is selected via Select", () => {
+		const component = (
+			<Provider store={store}>
+				<Router history={history}>
+					<IntlProvider locale="en-US" messages={messages}>
+						<TabBar module={module} pages={pages} />
+					</IntlProvider>
+				</Router>
+			</Provider>
+		);
+
+		const setState = jest.fn();
+		const useStateSpy = jest.spyOn(React, "useState");
+		useStateSpy.mockImplementation(() => [true, setState]);
+
+		const mountedComponent = mount(component);
+
+		const select = mountedComponent.find(SelectMUI);
+
+		select.invoke("onChange")({ target: { value: 2 } });
+
+		expect(history.push, "to have a call satisfying", { args: [pages[2].href] });
+	});
+
+	it("Calls correct close callback when close icon for specific page tab is clicked and tab was not modified", () => {
+		const component = (
+			<Provider store={store}>
+				<MemoryRouter>
+					<IntlProvider locale="en-US" messages={messages}>
+						<TabBar module={module} pages={pages} />
+					</IntlProvider>
+				</MemoryRouter>
+			</Provider>
+		);
+
+		const mountedComponent = mount(component);
+
+		const pageTab = mountedComponent.find(Tab).at(1);
+		const closeIcon = pageTab.find(Icon);
+
+		closeIcon.simulate("click");
+
+		expect(pages[0].close, "was called");
+	});
+
+	it("Calls correct close callback when close icon for specific page tab is clicked and tab was modified", () => {
+		const component = (
+			<Provider store={store}>
+				<MemoryRouter>
+					<IntlProvider locale="en-US" messages={messages}>
+						<TabBar module={module} pages={pages} />
+					</IntlProvider>
+				</MemoryRouter>
+			</Provider>
+		);
+
+		const setState = sinon.spy();
+		const useStateSpy = jest.spyOn(React, "useState");
+		useStateSpy.mockImplementation(value => [value, setState]);
+
+		const mountedComponent = mount(component);
+
+		const pageTab = mountedComponent.find(Tab).at(3);
+		const closeIcon = pageTab.find(Icon);
+
+		closeIcon.simulate("click");
+
+		expect(setState, "to have a call satisfying", { args: [{ closeCallback: pages[2].close, href: pages[2].href }] });
+
+		expect(setState, "to have a call satisfying", { args: [true] });
+	});
+
+	it("Handles onResize correct when isScrollVisible returns false", () => {
+		const component = (
+			<Provider store={store}>
+				<MemoryRouter>
+					<IntlProvider locale="en-US" messages={messages}>
+						<TabBar module={module} pages={pages} />
+					</IntlProvider>
+				</MemoryRouter>
+			</Provider>
+		);
+
+		const setState = sinon.spy();
+		const useStateSpy = jest.spyOn(React, "useState");
+		useStateSpy.mockImplementation(value => [value, setState]);
+
+		const isScrollVisibleStub = sinon.stub(domHelper, "isScrollVisible").returns(false);
+
+		const mountedComponent = mount(component);
+
+		const resizeDetector = mountedComponent.find(ResizeDetector);
+
+		resizeDetector.invoke("onResize")();
+
+		expect(isScrollVisibleStub.getCall(0).args[0].className, "to equal", "MuiTabs-flexContainer");
+
+		expect(setState, "to have a call satisfying", { args: [false] });
+
+		isScrollVisibleStub.restore();
+		useStateSpy.mockRestore();
+	});
+
+	it("Handles onResize correct when isScrollVisible returns true", () => {
+		const component = (
+			<Provider store={store}>
+				<MemoryRouter>
+					<IntlProvider locale="en-US" messages={messages}>
+						<TabBar module={module} pages={pages} />
+					</IntlProvider>
+				</MemoryRouter>
+			</Provider>
+		);
+
+		const setState = sinon.spy();
+		const useStateSpy = jest.spyOn(React, "useState");
+		useStateSpy.mockImplementation(value => [value, setState]);
+
+		const mountedComponent = mount(component);
+
+		const isScrollVisibleStub = sinon.stub(domHelper, "isScrollVisible").returns(true);
+
+		const resizeDetector = mountedComponent.find(ResizeDetector);
+
+		resizeDetector.invoke("onResize")();
+
+		expect(isScrollVisibleStub.getCall(0).args[0].className, "to equal", "MuiTabs-flexContainer");
+
+		expect(setState, "to have a call satisfying", { args: [true] });
+
+		isScrollVisibleStub.restore();
+		useStateSpy.mockRestore();
+	});
+
+	it("Closes tab when ok callback in confirmation modal is triggered", () => {
+		const component = (
+			<Provider store={store}>
+				<MemoryRouter>
+					<IntlProvider locale="en-US" messages={messages}>
+						<TabBar module={module} pages={pages} />
+					</IntlProvider>
+				</MemoryRouter>
+			</Provider>
+		);
+
+		const dispatchSpy = sinon.spy();
+		const useDispatchWithModulesDataStub = sinon
+			.stub(useDispatchWithModulesData, "useDispatchWithModulesData")
+			.returns(dispatchSpy);
+
+		const useStateStub = sinon.stub(ReactMock, "useState");
+		useStateStub.withArgs(undefined).returns([{ closeCallback: pages[2].close, href: pages[2].href }, jest.fn()]);
+
+		const mountedComponent = mount(component);
+
+		const pageTab = mountedComponent.find(Tab).at(3);
+		const closeIcon = pageTab.find(Icon);
+
+		closeIcon.simulate("click");
+
+		let confirmationModal = mountedComponent.find(ConfirmationModal);
+
+		confirmationModal.invoke("okCallback")();
+
+		confirmationModal = mountedComponent.find(ConfirmationModal);
+
+		expect(confirmationModal.prop("open"), "to be false");
+		expect(pages[2].close, "was called");
+		expect(dispatchSpy, "to have a call satisfying", { args: [removeEditNode, [pages[2].params.entityId]] });
+
+		useDispatchWithModulesDataStub.restore();
+		useStateStub.restore();
+	});
+
+	it("Closes confirmation modal when cancelCallback is triggered", () => {
+		const component = (
+			<Provider store={store}>
+				<MemoryRouter>
+					<IntlProvider locale="en-US" messages={messages}>
+						<TabBar module={module} pages={pages} />
+					</IntlProvider>
+				</MemoryRouter>
+			</Provider>
+		);
+
+		const mountedComponent = mount(component);
+
+		const pageTab = mountedComponent.find(Tab).at(3);
+		const closeIcon = pageTab.find(Icon);
+
+		closeIcon.simulate("click");
+
+		let confirmationModal = mountedComponent.find(ConfirmationModal);
+
+		confirmationModal.invoke("cancelCallback")();
+
+		confirmationModal = mountedComponent.find(ConfirmationModal);
+
+		expect(confirmationModal.prop("open"), "to be false");
+	});
+
+	it("Closes confirmation modal when backdropClickCallback is triggered", () => {
+		const component = (
+			<Provider store={store}>
+				<MemoryRouter>
+					<IntlProvider locale="en-US" messages={messages}>
+						<TabBar module={module} pages={pages} />
+					</IntlProvider>
+				</MemoryRouter>
+			</Provider>
+		);
+
+		const mountedComponent = mount(component);
+
+		const pageTab = mountedComponent.find(Tab).at(3);
+		const closeIcon = pageTab.find(Icon);
+
+		closeIcon.simulate("click");
+
+		let confirmationModal = mountedComponent.find(ConfirmationModal);
+
+		confirmationModal.invoke("backdropClickCallback")();
+
+		confirmationModal = mountedComponent.find(ConfirmationModal);
+
+		expect(confirmationModal.prop("open"), "to be false");
+	});
+
+	it("Remove edit mode for new tab with modifications when close ok callback in confirmation modal is triggered", () => {
+		const component = (
+			<Provider store={store}>
+				<MemoryRouter>
+					<IntlProvider locale="en-US" messages={messages}>
+						<TabBar module={module} pages={pages} />
+					</IntlProvider>
+				</MemoryRouter>
+			</Provider>
+		);
+
+		const dispatchSpy = sinon.spy();
+		const useDispatchWithModulesDataStub = sinon
+			.stub(useDispatchWithModulesData, "useDispatchWithModulesData")
+			.returns(dispatchSpy);
+
+		const useStateStub = sinon.stub(ReactMock, "useState");
+		useStateStub.withArgs(undefined).returns([{ closeCallback: pages[3].close, href: pages[3].href }, jest.fn()]);
+
+		const mountedComponent = mount(component);
+
+		const pageTab = mountedComponent.find(Tab).at(4);
+		const closeIcon = pageTab.find(Icon);
+
+		closeIcon.simulate("click");
+
+		let confirmationModal = mountedComponent.find(ConfirmationModal);
+
+		confirmationModal.invoke("okCallback")();
+
+		confirmationModal = mountedComponent.find(ConfirmationModal);
+
+		expect(confirmationModal.prop("open"), "to be false");
+		expect(pages[3].close, "was called");
+		expect(dispatchSpy, "to have a call satisfying", { args: [removeEditNode, ["new"]] });
+
+		useDispatchWithModulesDataStub.restore();
+		useStateStub.restore();
+	});
 });
 
 describe("TabLink", () => {
-  it("Renders TabLink correctly", () => {
-    const href = "link";
-    const child = <div>child</div>;
-    const close = <div>close</div>;
+	it("Renders TabLink correctly", () => {
+		const href = "link";
+		const child = <div>child</div>;
+		const close = <div>close</div>;
 
-    const component = (
-      <MemoryRouter>
-        <TabLink to={href} close={close}>
-          {child}
-        </TabLink>
-      </MemoryRouter>
-    );
+		const component = (
+			<MemoryRouter>
+				<TabLink to={href} close={close}>
+					{child}
+				</TabLink>
+			</MemoryRouter>
+		);
 
-    const expected = (
-      <MemoryRouter>
-        <Link to={href}>
-          {child}
-          {close}
-        </Link>
-      </MemoryRouter>
-    );
+		const expected = (
+			<MemoryRouter>
+				<Link to={href}>
+					{child}
+					{close}
+				</Link>
+			</MemoryRouter>
+		);
 
-    expect(component, "when mounted", "to satisfy", expected);
-  });
+		expect(component, "when mounted", "to satisfy", expected);
+	});
 });

--- a/src/selectors/view.js
+++ b/src/selectors/view.js
@@ -1,92 +1,84 @@
 import { createSelector } from "reselect";
 import { selectCurrentModuleName } from "./navigation";
 import { isObjectContainsPropertyWithValue } from "./../utils/propertyHelper";
+import { tryGetNewEntityIdKey } from "./../utils/urlHelper";
 
 const modulesData = state => state.get("view");
 
 const editData = createSelector(modulesData, data => data.get("edit"));
 
-export const isEntityUnderEditing = (entityId) => createSelector(
-  editData,
-  selectCurrentModuleName,
-  (data, moduleName) => {
-    if (data != null) {
-      const dataJS = data.toJS();
-      const sections = dataJS[moduleName][entityId];
-      if (sections != null) {
-        return true;
-      }
-    }
-    return false;
-  },
-);
+export const isEntityUnderEditing = entityId =>
+	createSelector(editData, selectCurrentModuleName, (data, moduleName) => {
+		if (data != null) {
+			const dataJS = data.toJS();
+			const sections = dataJS[moduleName][entityId];
+			if (sections != null) {
+				return true;
+			}
+		}
+		return false;
+	});
 
-export const getModifiedSections = (entityId) => createSelector(
-  editData,
-  selectCurrentModuleName,
-  (data, moduleName) => {
-    return getModifiedSectionsFromModule(data, moduleName, entityId);
-  },
-);
+export const getModifiedSections = entityId =>
+	createSelector(editData, selectCurrentModuleName, (data, moduleName) => {
+		return getModifiedSectionsFromModule(data, moduleName, entityId);
+	});
 
 const getModifiedSectionsFromModule = (editData, moduleName, entityId) => {
-  const modifiedSections = [];
-  if (editData != null) {
-    const dataJS = editData.toJS();
-    const sections = dataJS[moduleName][entityId];
-    if (sections != null) {
-      const sectionsKeys = Object.keys(sections);
-      for (const sectionKey of sectionsKeys) {
-        const sectionModel = sections[sectionKey].model;
+	const modifiedSections = [];
+	if (editData != null) {
+		const dataJS = editData.toJS();
+		const sections = dataJS[moduleName][entityId];
+		if (sections != null) {
+			const sectionsKeys = Object.keys(sections);
+			for (const sectionKey of sectionsKeys) {
+				const sectionModel = sections[sectionKey].model;
 
-        if (sectionModel != null) {
-          const wasModified = isObjectContainsPropertyWithValue(sectionModel, "wasModified", true);
-          if (wasModified === true) {
-            modifiedSections.push(sectionKey);
-          }
-        }
-      }
-    }
-  }
-  return modifiedSections;
-}
+				if (sectionModel != null) {
+					const wasModified = isObjectContainsPropertyWithValue(sectionModel, "wasModified", true);
+					if (wasModified === true) {
+						modifiedSections.push(sectionKey);
+					}
+				}
+			}
+		}
+	}
+	return modifiedSections;
+};
 
-export const getModifiedTabs = (tabsParams) => createSelector(
-  editData,
-  selectCurrentModuleName,
-  (data, moduleName) => {
-    const modifiedTabs = [];
+export const getModifiedTabs = tabsParams =>
+	createSelector(editData, selectCurrentModuleName, (data, moduleName) => {
+		const modifiedTabs = [];
 
-    tabsParams.forEach(tabParams => {
-      for (let i = 0; i < tabParams.params.length; i++) {
-        const modifiedSections = getModifiedSectionsFromModule(data, moduleName, tabParams.params[i]);
-        if (modifiedSections.length > 0) {
-          modifiedTabs.push(tabParams.href);
-          break;
-        }
-      }
-    });
+		tabsParams.forEach(tabParams => {
+			let newEntityId = tryGetNewEntityIdKey(tabParams.href);
+			if (newEntityId) tabParams.params.push(newEntityId);
 
-    return modifiedTabs;
-  }
-)
+			for (let i = 0; i < tabParams.params.length; i++) {
+				const modifiedSections = getModifiedSectionsFromModule(data, moduleName, tabParams.params[i]);
+				if (modifiedSections.length > 0) {
+					modifiedTabs.push(tabParams.href);
+					break;
+				}
+			}
+		});
 
-export const getModifiedModels = (entityId) => createSelector(
-  editData,
-  selectCurrentModuleName,
-  (data, moduleName) => {
-    const models = {};
-    if (data != null) {
-      const dataJS = data.toJS();
-      const sections = dataJS[moduleName][entityId];
-      if (sections != null) {
-        const sectionsKeys = Object.keys(sections);
+		return modifiedTabs;
+	});
 
-        sectionsKeys.forEach(sectionKey => {
-          models[sectionKey] = sections[sectionKey].model;
-        });
-      }
-    }
-    return models;
-  }
-);
+export const getModifiedModels = entityId =>
+	createSelector(editData, selectCurrentModuleName, (data, moduleName) => {
+		const models = {};
+		if (data != null) {
+			const dataJS = data.toJS();
+			const sections = dataJS[moduleName][entityId];
+			if (sections != null) {
+				const sectionsKeys = Object.keys(sections);
+
+				sectionsKeys.forEach(sectionKey => {
+					models[sectionKey] = sections[sectionKey].model;
+				});
+			}
+		}
+		return models;
+	});

--- a/src/selectors/view.test.js
+++ b/src/selectors/view.test.js
@@ -1,273 +1,261 @@
 import Immutable from "immutable";
-import {
-  isEntityUnderEditing,
-  getModifiedSections,
-  getModifiedModels,
-  getModifiedTabs
-} from "./view";
+import { isEntityUnderEditing, getModifiedSections, getModifiedModels, getModifiedTabs } from "./view";
 
 describe("isEntityUnderEditing", () => {
-  let state, stateWithEmptyEdit;
-  beforeEach(() => {
-    state = Immutable.fromJS({
-      view: {
-        edit: {
-          module1: {
-            id1: {
-              section1: {}
-            }
-          }
-        },
-      },
-      navigation: {
-        route: { match: { path: "/:scope/module1/id1/section1" } },
-        config: { prependPath: "/:scope/", prependHref: "/scope/" },
-      }
-    });
-    stateWithEmptyEdit = Immutable.fromJS({
-      view: {},
-      navigation: {
-        route: { match: { path: "/:scope/module1/id1/section1" } },
-        config: { prependPath: "/:scope/", prependHref: "/scope/" },
-      }
-    })
-  });
+	let state, stateWithEmptyEdit;
+	beforeEach(() => {
+		state = Immutable.fromJS({
+			view: {
+				edit: {
+					module1: {
+						id1: {
+							section1: {},
+						},
+					},
+				},
+			},
+			navigation: {
+				route: { match: { path: "/:scope/module1/id1/section1" } },
+				config: { prependPath: "/:scope/", prependHref: "/scope/" },
+			},
+		});
+		stateWithEmptyEdit = Immutable.fromJS({
+			view: {},
+			navigation: {
+				route: { match: { path: "/:scope/module1/id1/section1" } },
+				config: { prependPath: "/:scope/", prependHref: "/scope/" },
+			},
+		});
+	});
 
-  it("Retrieves true if specified entity is under editing", () => {
-    expect(isEntityUnderEditing, "when called with", ["id1"], "called with", [state], "to satisfy", true);
-  });
+	it("Retrieves true if specified entity is under editing", () => {
+		expect(isEntityUnderEditing, "when called with", ["id1"], "called with", [state], "to satisfy", true);
+	});
 
-  it("Retrieves false if specified entity is not under editing or not found", () => {
-    expect(isEntityUnderEditing, "when called with", ["id12"], "called with", [state], "to satisfy", false);
-  });
+	it("Retrieves false if specified entity is not under editing or not found", () => {
+		expect(isEntityUnderEditing, "when called with", ["id12"], "called with", [state], "to satisfy", false);
+	});
 
-  it("Retrieves false if edit is missing from the store", () => {
-    expect(isEntityUnderEditing, "when called with", ["id2"], "called with", [stateWithEmptyEdit], "to satisfy", false);
-  });
+	it("Retrieves false if edit is missing from the store", () => {
+		expect(isEntityUnderEditing, "when called with", ["id2"], "called with", [stateWithEmptyEdit], "to satisfy", false);
+	});
 });
 
 describe("getModifiedSections", () => {
-  let state, stateWithEmptyEdit;
-  beforeEach(() => {
-    state = Immutable.fromJS({
-      view: {
-        edit: {
-          module1: {
-            id1: {
-              section1: {},
-              section2: {
-                model: {
-                  field1: {
-                    value: "smth",
-                    wasModified: true
-                  }
-                }
-              },
-              section3: {
-                model: {
-                  field1: {
-                    value: "another",
-                    wasModified: false
-                  }
-                }
-              }
-            }
-          }
-        },
-      },
-      navigation: {
-        route: { match: { path: "/:scope/module1/id1/section1" } },
-        config: { prependPath: "/:scope/", prependHref: "/scope/" },
-      }
-    });
+	let state, stateWithEmptyEdit;
+	beforeEach(() => {
+		state = Immutable.fromJS({
+			view: {
+				edit: {
+					module1: {
+						id1: {
+							section1: {},
+							section2: {
+								model: {
+									field1: {
+										value: "smth",
+										wasModified: true,
+									},
+								},
+							},
+							section3: {
+								model: {
+									field1: {
+										value: "another",
+										wasModified: false,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			navigation: {
+				route: { match: { path: "/:scope/module1/id1/section1" } },
+				config: { prependPath: "/:scope/", prependHref: "/scope/" },
+			},
+		});
 
-    stateWithEmptyEdit = Immutable.fromJS({
-      view: {},
-      navigation: {
-        route: { match: { path: "/:scope/module1/id1/section1" } },
-        config: { prependPath: "/:scope/", prependHref: "/scope/" },
-      }
-    })
-  });
+		stateWithEmptyEdit = Immutable.fromJS({
+			view: {},
+			navigation: {
+				route: { match: { path: "/:scope/module1/id1/section1" } },
+				config: { prependPath: "/:scope/", prependHref: "/scope/" },
+			},
+		});
+	});
 
-  it("Retrieves modified sections", () => {
-    expect(getModifiedSections, "when called with", ["id1"], "called with", [state], "to satisfy", ["section2"]);
-  });
+	it("Retrieves modified sections", () => {
+		expect(getModifiedSections, "when called with", ["id1"], "called with", [state], "to satisfy", ["section2"]);
+	});
 
-  it("Retrieves empty array if no sections found or no sections were modified", () => {
-    expect(getModifiedSections, "when called with", ["id2"], "called with", [state], "to satisfy", []);
-  });
+	it("Retrieves empty array if no sections found or no sections were modified", () => {
+		expect(getModifiedSections, "when called with", ["id2"], "called with", [state], "to satisfy", []);
+	});
 
-  it("Retrieves empty array if edit is missing from the store", () => {
-    expect(getModifiedSections, "when called with", ["id2"], "called with", [stateWithEmptyEdit], "to satisfy", []);
-  });
+	it("Retrieves empty array if edit is missing from the store", () => {
+		expect(getModifiedSections, "when called with", ["id2"], "called with", [stateWithEmptyEdit], "to satisfy", []);
+	});
 });
 
 describe("getModifiedModels", () => {
-  let state, stateWithEmptyEdit;
-  beforeEach(() => {
-    state = Immutable.fromJS({
-      view: {
-        edit: {
-          module1: {
-            id1: {
-              section1: {
-                model: {
-                  key11: "value11",
-                  key12: "value12"
-                }
-              },
-              section2: {
-                model: {
-                  key21: "value21",
-                  key22: "value22",
-                  key23: {
-                    key33: "value33"
-                  }
-                }
-              }
-            }
-          }
-        },
-      },
-      navigation: {
-        route: { match: { path: "/:scope/module1/id1/section1" } },
-        config: { prependPath: "/:scope/", prependHref: "/scope/" },
-      }
-    });
+	let state, stateWithEmptyEdit;
+	beforeEach(() => {
+		state = Immutable.fromJS({
+			view: {
+				edit: {
+					module1: {
+						id1: {
+							section1: {
+								model: {
+									key11: "value11",
+									key12: "value12",
+								},
+							},
+							section2: {
+								model: {
+									key21: "value21",
+									key22: "value22",
+									key23: {
+										key33: "value33",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			navigation: {
+				route: { match: { path: "/:scope/module1/id1/section1" } },
+				config: { prependPath: "/:scope/", prependHref: "/scope/" },
+			},
+		});
 
-    stateWithEmptyEdit = Immutable.fromJS({
-      view: {},
-      navigation: {
-        route: { match: { path: "/:scope/module1/id1/section1" } },
-        config: { prependPath: "/:scope/", prependHref: "/scope/" },
-      }
-    })
-  });
+		stateWithEmptyEdit = Immutable.fromJS({
+			view: {},
+			navigation: {
+				route: { match: { path: "/:scope/module1/id1/section1" } },
+				config: { prependPath: "/:scope/", prependHref: "/scope/" },
+			},
+		});
+	});
 
-  it("Retrieves modified sections", () => {
-    expect(getModifiedModels, "when called with", ["id1"], "called with", [state], "to satisfy", {
-      section1: {
-        key11: "value11",
-        key12: "value12"
-      },
-      section2: {
-        key21: "value21",
-        key22: "value22",
-        key23: {
-          key33: "value33"
-        }
-      }
-    });
-  });
+	it("Retrieves modified sections", () => {
+		expect(getModifiedModels, "when called with", ["id1"], "called with", [state], "to satisfy", {
+			section1: {
+				key11: "value11",
+				key12: "value12",
+			},
+			section2: {
+				key21: "value21",
+				key22: "value22",
+				key23: {
+					key33: "value33",
+				},
+			},
+		});
+	});
 
-  it("Retrieves empty array if no sections found or no sections were modified", () => {
-    expect(getModifiedModels, "when called with", ["id2"], "called with", [state], "to satisfy", {});
-  });
+	it("Retrieves empty array if no sections found or no sections were modified", () => {
+		expect(getModifiedModels, "when called with", ["id2"], "called with", [state], "to satisfy", {});
+	});
 
-  it("Retrieves empty array if edit is missing from the store", () => {
-    expect(getModifiedModels, "when called with", ["id2"], "called with", [stateWithEmptyEdit], "to satisfy", {});
-  });
+	it("Retrieves empty array if edit is missing from the store", () => {
+		expect(getModifiedModels, "when called with", ["id2"], "called with", [stateWithEmptyEdit], "to satisfy", {});
+	});
 });
 
 describe("getModifiedTabs", () => {
-  let state, stateWithEmptyEdit;
-  beforeEach(() => {
-    state = Immutable.fromJS({
-      view: {
-        edit: {
-          module1: {
-            id1: {
-              section1: {
-              },
-              section2: {
-                model: {
-                  field1: {
-                    value: "smth",
-                    wasModified: true
-                  }
-                }
-              }
-            },
-            id2: {
-              section1: {
-              },
-              section2: {
-              }
-            }
-          }
-        },
-      },
-      navigation: {
-        route: { match: { path: "/:scope/module1/id1/section1" } },
-        config: { prependPath: "/:scope/", prependHref: "/scope/" },
-      }
-    });
+	let state, stateWithEmptyEdit;
+	beforeEach(() => {
+		state = Immutable.fromJS({
+			view: {
+				edit: {
+					module1: {
+						id1: {
+							section1: {},
+							section2: {
+								model: {
+									field1: {
+										value: "smth",
+										wasModified: true,
+									},
+								},
+							},
+						},
+						id2: {
+							section1: {},
+							section2: {},
+						},
+						new: {
+							section1: {
+								model: {
+									field1: {
+										value: "smth",
+										wasModified: true,
+									},
+								},
+							},
+							section2: {},
+						},
+					},
+				},
+			},
+			navigation: {
+				route: { match: { path: "/:scope/module1/id1/section1" } },
+				config: { prependPath: "/:scope/", prependHref: "/scope/" },
+			},
+		});
 
-    stateWithEmptyEdit = Immutable.fromJS({
-      view: {},
-      navigation: {
-        route: { match: { path: "/:scope/module1/id1/section1" } },
-        config: { prependPath: "/:scope/", prependHref: "/scope/" },
-      }
-    })
-  });
+		stateWithEmptyEdit = Immutable.fromJS({
+			view: {},
+			navigation: {
+				route: { match: { path: "/:scope/module1/id1/section1" } },
+				config: { prependPath: "/:scope/", prependHref: "/scope/" },
+			},
+		});
+	});
 
-  it("Retrieves modified tabs correctly when edit is not empty", () => {
-    const tabParams = [
-      {
-        href: "id1Href",
-        params: [
-          "Global",
-          "id1"
-        ]
-      },
-      {
-        href: "id2Href",
-        params: [
-          "Global",
-          "id2"
-        ]
-      }
-    ];
+	it("Retrieves modified tabs correctly when edit is not empty", () => {
+		const tabParams = [
+			{
+				href: "id1Href",
+				params: ["Global", "id1"],
+			},
+			{
+				href: "id2Href",
+				params: ["Global", "id2"],
+			},
+		];
 
-    expect(getModifiedTabs,
-      "when called with",
-      [tabParams],
-      "called with",
-      [state],
-      "to satisfy",
-      [
-        "id1Href"
-      ]
-    );
-  });
+		expect(getModifiedTabs, "when called with", [tabParams], "called with", [state], "to satisfy", ["id1Href"]);
+	});
 
-  it("Retrieves empty array when edit is empty", () => {
-    const tabParams = [
-      {
-        href: "id1Href",
-        params: [
-          "Global",
-          "id1"
-        ]
-      },
-      {
-        href: "id2Href",
-        params: [
-          "Global",
-          "id2"
-        ]
-      }
-    ];
+	it("Retrieves empty array when edit is empty", () => {
+		const tabParams = [
+			{
+				href: "id1Href",
+				params: ["Global", "id1"],
+			},
+			{
+				href: "id2Href",
+				params: ["Global", "id2"],
+			},
+		];
 
-    expect(getModifiedTabs,
-      "when called with",
-      [tabParams],
-      "called with",
-      [stateWithEmptyEdit],
-      "to satisfy",
-      []
-    );
-  });
-}); 
+		expect(getModifiedTabs, "when called with", [tabParams], "called with", [stateWithEmptyEdit], "to satisfy", []);
+	});
+
+	it("Add new entity id to tab params when parsed in URL", () => {
+		const tabParams = [
+			{
+				href: "/Global/module1/new/section1",
+				params: ["Global"],
+			},
+		];
+
+		expect(getModifiedTabs, "when called with", [tabParams], "called with", [state], "to satisfy", [
+			"/Global/module1/new/section1",
+		]);
+	});
+});

--- a/src/utils/urlHelper.js
+++ b/src/utils/urlHelper.js
@@ -13,16 +13,15 @@ export const NEW_ENTITY_URL_KEY = "new";
 	/new => new
 	/new/section => new
 	/new{number} => new{number}
-	/new{number}/section => new{number}	
+	/new{number}/section => new{number}
 */
 export const tryGetNewEntityIdKey = url => {
-	if (url.endsWith(`/${NEW_ENTITY_URL_KEY}`) || url.indexOf(`/${NEW_ENTITY_URL_KEY}/`) >= 0) return NEW_ENTITY_URL_KEY;
+	const valuesFromUrl = url.split("/");
+	if (valuesFromUrl.length < 2) return;
 
-	let match = url.match(`/(${NEW_ENTITY_URL_KEY}[0-9]+$)`);
-	if (match) return match[1];
-
-	match = url.match(`/(${NEW_ENTITY_URL_KEY}[0-9]+)(/+)`);
-	if (match) return match[1];
-
-	return undefined;
+	for (const section of valuesFromUrl) {
+		if (section === NEW_ENTITY_URL_KEY) return section;
+		let match = section.match(`(${NEW_ENTITY_URL_KEY}[0-9]+$)`);
+		if (match) return match[1];
+	}
 };

--- a/src/utils/urlHelper.js
+++ b/src/utils/urlHelper.js
@@ -1,9 +1,28 @@
 export const getValueFromUrlByKey = (url, path, key) => {
-  const valuesFromUrl = url.split('/');
+	const valuesFromUrl = url.split("/");
 
-  const keysFromPath = path.split('/');
+	const keysFromPath = path.split("/");
 
-  const keyIndex = keysFromPath.indexOf(key);
+	const keyIndex = keysFromPath.indexOf(key);
 
-  return valuesFromUrl[keyIndex];
-}
+	return valuesFromUrl[keyIndex];
+};
+
+export const NEW_ENTITY_URL_KEY = "new";
+/* expected url formats for new mode:
+	/new => new
+	/new/section => new
+	/new{number} => new{number}
+	/new{number}/section => new{number}	
+*/
+export const tryGetNewEntityIdKey = url => {
+	if (url.endsWith(`/${NEW_ENTITY_URL_KEY}`) || url.indexOf(`/${NEW_ENTITY_URL_KEY}/`) >= 0) return NEW_ENTITY_URL_KEY;
+
+	let match = url.match(`/(${NEW_ENTITY_URL_KEY}[0-9]+$)`);
+	if (match) return match[1];
+
+	match = url.match(`/(${NEW_ENTITY_URL_KEY}[0-9]+)(/+)`);
+	if (match) return match[1];
+
+	return undefined;
+};

--- a/src/utils/urlHelper.test.js
+++ b/src/utils/urlHelper.test.js
@@ -1,13 +1,105 @@
-import { getValueFromUrlByKey } from "./urlHelper";
+import { getValueFromUrlByKey, tryGetNewEntityIdKey } from "./urlHelper";
 
 describe("getEntityIdFromUrl", () => {
-  it("Retrieves entity id from url", () => {
-    const url = "/prependPath/module/entityId/section";
+	it("Retrieves entity id from url", () => {
+		const url = "/prependPath/module/entityId/section";
 
-    const path = "/:scope/module/:entityId/section";
+		const path = "/:scope/module/:entityId/section";
 
-    const entityId = getValueFromUrlByKey(url, path, ":entityId");
+		const entityId = getValueFromUrlByKey(url, path, ":entityId");
 
-    expect(entityId, "to equal", "entityId");
-  });
+		expect(entityId, "to equal", "entityId");
+	});
+});
+
+describe("tryGetNewEntityIdKey", () => {
+	it("should return undefined when new without / at begin", () => {
+		let url = "new";
+		let newEntityId = tryGetNewEntityIdKey(url);
+
+		return expect(newEntityId, "to be", undefined);
+	});
+
+	it("Should return new when url like /new", () => {
+		let url = "/new";
+		let newEntityId = tryGetNewEntityIdKey(url);
+		let expected = "new";
+
+		return expect(newEntityId, "to be", expected);
+	});
+
+	it("Should return new when url like /new/section", () => {
+		let url = "/new/somesection";
+		let newEntityId = tryGetNewEntityIdKey(url);
+		let expected = "new";
+
+		return expect(newEntityId, "to be", expected);
+	});
+
+	it("Should return new when url like /scope/module/new", () => {
+		let url = "/Global/somemodule/new";
+		let newEntityId = tryGetNewEntityIdKey(url);
+		let expected = "new";
+
+		return expect(newEntityId, "to be", expected);
+	});
+
+	it("Should return new when url like /scope/module/new/section", () => {
+		let url = "/Global/somemodule/new/somesection";
+		let newEntityId = tryGetNewEntityIdKey(url);
+		let expected = "new";
+
+		return expect(newEntityId, "to be", expected);
+	});
+
+	it("shoud return new{number} when url like /new{number}", () => {
+		let url = "/new1";
+		let newEntityId = tryGetNewEntityIdKey(url);
+		let expected = "new1";
+
+		return expect(newEntityId, "to be", expected);
+	});
+
+	it("shoud return new{number} when url like /new{number}/section", () => {
+		let url = "/new1/section";
+		let newEntityId = tryGetNewEntityIdKey(url);
+		let expected = "new1";
+
+		return expect(newEntityId, "to be", expected);
+	});
+
+	it("shoud return undefined when url like /new{not_number}", () => {
+		let url = "/newsomething";
+		let newEntityId = tryGetNewEntityIdKey(url);
+
+		return expect(newEntityId, "to be", undefined);
+	});
+
+	it("shoud return undefined when url like /new{not_number}/section", () => {
+		let url = "/newsomething/section";
+		let newEntityId = tryGetNewEntityIdKey(url);
+
+		return expect(newEntityId, "to be", undefined);
+	});
+
+	it("shoud return undefined when url like /new{number}{not_number}/section", () => {
+		let url = "/new123something/section";
+		let newEntityId = tryGetNewEntityIdKey(url);
+
+		return expect(newEntityId, "to be", undefined);
+	});
+
+	it("shoud return undefined when url like /{string}new", () => {
+		let url = "/somethingnew";
+		let newEntityId = tryGetNewEntityIdKey(url);
+
+		return expect(newEntityId, "to be", undefined);
+	});
+
+	it("shoud return undefined when url like /{string}new/section", () => {
+		let url = "/somethingnew/section";
+		let newEntityId = tryGetNewEntityIdKey(url);
+
+		return expect(newEntityId, "to be", undefined);
+	});
 });


### PR DESCRIPTION
Add modification indication * on NEW entity tab
Show confirmation modal when New tab with modifications is closing
Remove edit mode for New tab when tab is closed
![new-tab-cancel-button](https://user-images.githubusercontent.com/6649972/103267427-29440380-49ba-11eb-869d-81146df57c02.gif)

[AB#42239](https://dev.azure.com/orckestra001/da965986-c85b-43be-9915-219568b000e5/_workitems/edit/42239)
