### PR TITLE
Highlight sections with errors

### DIFF
--- a/src/actions/view.js
+++ b/src/actions/view.js
@@ -37,7 +37,7 @@ export const setEditModelErrors = (errors, entityId, sectionName, moduleName) =>
 	payload: { errors, entityId, sectionName, moduleName },
 });
 
-export const setEditModelFieldErrors = (keys, error, entityId, sectionName, moduleName) => ({
+export const setEditModelFieldError = (keys, error, entityId, sectionName, moduleName) => ({
 	type: VIEW_SET_EDIT_MODEL_FIELD_ERRORS,
 	payload: { keys, error, entityId, sectionName, moduleName },
 });

--- a/src/actions/view.js
+++ b/src/actions/view.js
@@ -4,6 +4,7 @@ export const VIEW_SET_FIELD = "VIEW_STATE_SET_FIELD";
 export const VIEW_CREATE_EDIT_NODE = "VIEW_CREATE_EDIT_NODE";
 export const VIEW_REMOVE_EDIT_NODE = "VIEW_REMOVE_EDIT_NODE";
 export const VIEW_SET_EDIT_MODEL_FIELD = "VIEW_SET_EDIT_MODEL_FIELD";
+export const VIEW_SET_EDIT_MODEL_ERRORS = "VIEW_SET_EDIT_MODEL_ERRORS";
 
 export const setValue = (name, value) => ({
 	type: VIEW_SET,
@@ -28,4 +29,8 @@ export const removeEditNode = (entityId, moduleName) => ({
 export const setEditModelField = (keys, value, storeValue, entityId, sectionName, moduleName) => ({
 	type: VIEW_SET_EDIT_MODEL_FIELD,
 	payload: { keys, value, storeValue, entityId, sectionName, moduleName },
+});
+export const setEditModelErrors = (errors, entityId, sectionName, moduleName) => ({
+	type: VIEW_SET_EDIT_MODEL_ERRORS,
+	payload: { errors, entityId, sectionName, moduleName },
 });

--- a/src/actions/view.js
+++ b/src/actions/view.js
@@ -5,6 +5,7 @@ export const VIEW_CREATE_EDIT_NODE = "VIEW_CREATE_EDIT_NODE";
 export const VIEW_REMOVE_EDIT_NODE = "VIEW_REMOVE_EDIT_NODE";
 export const VIEW_SET_EDIT_MODEL_FIELD = "VIEW_SET_EDIT_MODEL_FIELD";
 export const VIEW_SET_EDIT_MODEL_ERRORS = "VIEW_SET_EDIT_MODEL_ERRORS";
+export const VIEW_SET_EDIT_MODEL_FIELD_ERRORS = "VIEW_SET_EDIT_MODEL_FIELD_ERRORS";
 
 export const setValue = (name, value) => ({
 	type: VIEW_SET,
@@ -30,7 +31,13 @@ export const setEditModelField = (keys, value, storeValue, entityId, sectionName
 	type: VIEW_SET_EDIT_MODEL_FIELD,
 	payload: { keys, value, storeValue, entityId, sectionName, moduleName },
 });
+
 export const setEditModelErrors = (errors, entityId, sectionName, moduleName) => ({
 	type: VIEW_SET_EDIT_MODEL_ERRORS,
 	payload: { errors, entityId, sectionName, moduleName },
+});
+
+export const setEditModelFieldErrors = (keys, error, entityId, sectionName, moduleName) => ({
+	type: VIEW_SET_EDIT_MODEL_FIELD_ERRORS,
+	payload: { keys, error, entityId, sectionName, moduleName },
 });

--- a/src/components/Routing/SegmentPage.js
+++ b/src/components/Routing/SegmentPage.js
@@ -30,12 +30,6 @@ const useStyles = makeStyles(theme => ({
 		fontSize: theme.typography.fontSize,
 		maxWidth: theme.spacing(15),
 	},
-	errorLabel: {
-		color: theme.palette.error.main,
-		fontWeight: theme.typography.fontWeightSemiBold,
-		fontSize: theme.typography.fontSize,
-		maxWidth: theme.spacing(15),
-	},
 	labelComponent: {
 		margin: `0 ${theme.spacing(1)}`,
 	},

--- a/src/components/Routing/SegmentPage.js
+++ b/src/components/Routing/SegmentPage.js
@@ -89,7 +89,9 @@ const SegmentPage = ({ path, component: View, segments, location, match, moduleP
 		subpages = [];
 	const entityIdKey = Object.keys(match.params).find(p => p !== "scope");
 	let entityId = match.params[entityIdKey];
-	if (!entityId) entityId = tryGetNewEntityIdKey(baseHref);
+	if (!entityId) {
+		entityId = tryGetNewEntityIdKey(baseHref);
+	}
 	const modifiedSections = useSelector(getModifiedSections(entityId));
 	const sectionsWithErrors = useSelector(getSectionsWithErrors(entityId));
 	const asterix = <span className={classes.asterix}>*</span>;

--- a/src/components/Routing/SegmentPage.js
+++ b/src/components/Routing/SegmentPage.js
@@ -8,7 +8,7 @@ import { TabBar } from "../Navigation/Bar";
 import FullPage from "./FullPage";
 import SubPage from "./SubPage";
 import Segment from "./Segment";
-import { getModifiedSections } from "./../../selectors/view";
+import { getModifiedSections, getSectionsWithErrors } from "./../../selectors/view";
 import { useSelector } from "react-redux";
 import { makeStyles } from "@material-ui/core/styles";
 import Grid from "@material-ui/core/Grid";
@@ -20,6 +20,18 @@ const useStyles = makeStyles(theme => ({
 	},
 	label: {
 		color: theme.palette.text.primary,
+		fontWeight: theme.typography.fontWeightSemiBold,
+		fontSize: theme.typography.fontSize,
+		maxWidth: theme.spacing(15),
+	},
+	errorLabel: {
+		color: theme.palette.error.main,
+		fontWeight: theme.typography.fontWeightSemiBold,
+		fontSize: theme.typography.fontSize,
+		maxWidth: theme.spacing(15),
+	},
+	errorLabel: {
+		color: theme.palette.error.main,
 		fontWeight: theme.typography.fontWeightSemiBold,
 		fontSize: theme.typography.fontSize,
 		maxWidth: theme.spacing(15),
@@ -83,6 +95,7 @@ const SegmentPage = ({ path, component: View, segments, location, match, moduleP
 	const entityIdKey = Object.keys(match.params).find(p => p !== "scope");
 	const entityId = match.params[entityIdKey];
 	const modifiedSections = useSelector(getModifiedSections(entityId));
+	const sectionsWithErrors = useSelector(getSectionsWithErrors(entityId));
 	const asterix = <span className={classes.asterix}>*</span>;
 	const segmentElements = Object.entries(segments).map(([segpath, config]) => {
 		if (config.pages) {
@@ -150,7 +163,14 @@ const SegmentPage = ({ path, component: View, segments, location, match, moduleP
 
 								const finalLabel = (
 									<Grid container justify="space-between">
-										<Grid item className={classes.label}>
+										<Grid
+											item
+											className={
+												sectionsWithErrors.includes(segpath.replace("/", "")) === true
+													? classes.errorLabel
+													: classes.label
+											}
+										>
 											{basicLabel}
 											{modifiedSections.includes(segpath.replace("/", "")) === true ? asterix : null}
 										</Grid>

--- a/src/components/Routing/SegmentPage.js
+++ b/src/components/Routing/SegmentPage.js
@@ -27,7 +27,7 @@ const useStyles = makeStyles(theme => ({
 	},
 	errorLabel: {
 		color: theme.palette.error.main,
-		fontWeight: theme.typography.fontWeightSemiBold,
+		fontWeight: theme.typography.fontWeightBold,
 		fontSize: theme.typography.fontSize,
 		maxWidth: theme.spacing(15),
 	},

--- a/src/components/Routing/SegmentPage.js
+++ b/src/components/Routing/SegmentPage.js
@@ -13,6 +13,7 @@ import { useSelector } from "react-redux";
 import { makeStyles } from "@material-ui/core/styles";
 import Grid from "@material-ui/core/Grid";
 import TooltippedTypography from "./../MaterialUI/DataDisplay/TooltippedElements/TooltippedTypography";
+import { tryGetNewEntityIdKey } from "./../../utils/urlHelper";
 
 const useStyles = makeStyles(theme => ({
 	asterix: {
@@ -87,7 +88,8 @@ const SegmentPage = ({ path, component: View, segments, location, match, moduleP
 	const pages = [],
 		subpages = [];
 	const entityIdKey = Object.keys(match.params).find(p => p !== "scope");
-	const entityId = match.params[entityIdKey];
+	let entityId = match.params[entityIdKey];
+	if (!entityId) entityId = tryGetNewEntityIdKey(baseHref);
 	const modifiedSections = useSelector(getModifiedSections(entityId));
 	const sectionsWithErrors = useSelector(getSectionsWithErrors(entityId));
 	const asterix = <span className={classes.asterix}>*</span>;
@@ -160,13 +162,11 @@ const SegmentPage = ({ path, component: View, segments, location, match, moduleP
 										<Grid
 											item
 											className={
-												sectionsWithErrors.includes(segpath.replace("/", "")) === true
-													? classes.errorLabel
-													: classes.label
+												sectionsWithErrors.includes(segpath.replace("/", "")) ? classes.errorLabel : classes.label
 											}
 										>
 											{basicLabel}
-											{modifiedSections.includes(segpath.replace("/", "")) === true ? asterix : null}
+											{modifiedSections.includes(segpath.replace("/", "")) ? asterix : null}
 										</Grid>
 										<Grid item className={classes.labelComponent}>
 											{config.labelComponent}

--- a/src/components/Routing/SegmentPage.test.js
+++ b/src/components/Routing/SegmentPage.test.js
@@ -46,6 +46,7 @@ describe("SegmentPage", () => {
 									field1: {
 										value: "smth",
 										wasModified: true,
+										error: "error",
 									},
 								},
 							},

--- a/src/reducers/view.js
+++ b/src/reducers/view.js
@@ -5,6 +5,7 @@ import {
 	VIEW_CREATE_EDIT_NODE,
 	VIEW_REMOVE_EDIT_NODE,
 	VIEW_SET_EDIT_MODEL_FIELD,
+	VIEW_SET_EDIT_MODEL_ERRORS,
 } from "../actions/view";
 import { isEqual } from "lodash";
 
@@ -41,6 +42,17 @@ const viewStateReducer = (state = initialState, action) => {
 			const path = ["edit", moduleName, entityId, sectionName, "model"].concat(keys);
 
 			return state.setIn(path, Immutable.fromJS({ value, wasModified: !isEqual(value, storeValue) }));
+		}
+		case VIEW_SET_EDIT_MODEL_ERRORS: {
+			const { errors, entityId, sectionName, moduleName } = action.payload;
+			errors.forEach(item => {
+				if (item.keys) {
+					const path = ["edit", moduleName, entityId, sectionName, "model"].concat(item.keys).concat(["error"]);
+					state = state.setIn(path, item.error);
+				}
+			});
+
+			return state;
 		}
 		default:
 			return state;

--- a/src/reducers/view.js
+++ b/src/reducers/view.js
@@ -5,6 +5,7 @@ import {
 	VIEW_CREATE_EDIT_NODE,
 	VIEW_REMOVE_EDIT_NODE,
 	VIEW_SET_EDIT_MODEL_FIELD,
+	VIEW_SET_EDIT_MODEL_FIELD_ERRORS,
 	VIEW_SET_EDIT_MODEL_ERRORS,
 } from "../actions/view";
 import { isEqual } from "lodash";
@@ -43,11 +44,16 @@ const viewStateReducer = (state = initialState, action) => {
 
 			return state.setIn(path, Immutable.fromJS({ value, wasModified: !isEqual(value, storeValue) }));
 		}
+		case VIEW_SET_EDIT_MODEL_FIELD_ERRORS: {
+			const { keys, error, entityId, sectionName, moduleName } = action.payload;
+			const path = ["edit", moduleName, entityId, sectionName, "model", ...keys, "error"];
+			return state.setIn(path, error);
+		}
 		case VIEW_SET_EDIT_MODEL_ERRORS: {
 			const { errors, entityId, sectionName, moduleName } = action.payload;
 			errors.forEach(item => {
 				if (item.keys) {
-					const path = ["edit", moduleName, entityId, sectionName, "model"].concat(item.keys).concat(["error"]);
+					const path = ["edit", moduleName, entityId, sectionName, "model", ...item.keys, "error"];
 					state = state.setIn(path, item.error);
 				}
 			});

--- a/src/reducers/view.test.js
+++ b/src/reducers/view.test.js
@@ -1,5 +1,13 @@
 import Immutable from "immutable";
-import { setValue, setStateField, createEditNode, removeEditNode, setEditModelField } from "../actions/view";
+import {
+	setValue,
+	setStateField,
+	createEditNode,
+	removeEditNode,
+	setEditModelField,
+	setEditModelFieldError,
+	setEditModelErrors,
+} from "../actions/view";
 import viewReducer from "./view";
 
 describe("View state reducer", () => {
@@ -142,6 +150,105 @@ describe("View state reducer", () => {
 		};
 
 		const action = removeEditNode(entityId, moduleName);
+		const newState = viewReducer(oldState, action);
+
+		return expect(newState, "not to be", oldState).and("to equal", Immutable.fromJS({ edit: expected }));
+	});
+
+	it("Sets field error inside model correctly", () => {
+		const keys = ["key1", "key2", "key3"];
+		const error = "error";
+		const entityId = "entityId";
+		const moduleName = "module1";
+		const sectionName = "section11";
+
+		const modules = Immutable.fromJS({
+			[moduleName]: {
+				[entityId]: {
+					[sectionName]: {},
+				},
+			},
+		});
+
+		const oldState = Immutable.Map({
+			edit: modules,
+		});
+
+		const model = {
+			key1: {
+				key2: {
+					key3: {
+						error: error,
+					},
+				},
+			},
+		};
+
+		const expected = {
+			[moduleName]: {
+				[entityId]: {
+					[sectionName]: {
+						model,
+					},
+				},
+			},
+		};
+
+		const action = setEditModelFieldError(keys, error, entityId, sectionName, moduleName);
+		const newState = viewReducer(oldState, action);
+
+		return expect(newState, "not to be", oldState).and("to equal", Immutable.fromJS({ edit: expected }));
+	});
+
+	it("Sets all errors inside model correctly", () => {
+		const errors = [
+			{ keys: ["key1", "key12", "key13"], error: "error1" },
+			{ keys: ["key2", "key21", "key23"], error: "error2" },
+		];
+		const entityId = "entityId";
+		const moduleName = "module1";
+		const sectionName = "section11";
+
+		const modules = Immutable.fromJS({
+			[moduleName]: {
+				[entityId]: {
+					[sectionName]: {},
+				},
+			},
+		});
+
+		const oldState = Immutable.Map({
+			edit: modules,
+		});
+
+		const model = {
+			key1: {
+				key12: {
+					key13: {
+						error: "error1",
+					},
+				},
+			},
+			key2: {
+				key21: {
+					key23: {
+						error: "error2",
+					},
+				},
+			},
+		};
+
+		const expected = {
+			[moduleName]: {
+				[entityId]: {
+					[sectionName]: {
+						model,
+					},
+				},
+			},
+		};
+
+		const action = setEditModelErrors(errors, entityId, sectionName, moduleName);
 		const newState = viewReducer(oldState, action);
 
 		return expect(newState, "not to be", oldState).and("to equal", Immutable.fromJS({ edit: expected }));

--- a/src/reducers/view.test.js
+++ b/src/reducers/view.test.js
@@ -253,4 +253,36 @@ describe("View state reducer", () => {
 
 		return expect(newState, "not to be", oldState).and("to equal", Immutable.fromJS({ edit: expected }));
 	});
+
+	it("Do not set error if keys is absent", () => {
+		const errors = [{ error: "error1" }];
+		const entityId = "entityId";
+		const moduleName = "module1";
+		const sectionName = "section11";
+
+		const modules = Immutable.fromJS({
+			[moduleName]: {
+				[entityId]: {
+					[sectionName]: {},
+				},
+			},
+		});
+
+		const oldState = Immutable.Map({
+			edit: modules,
+		});
+
+		const expected = {
+			[moduleName]: {
+				[entityId]: {
+					[sectionName]: {},
+				},
+			},
+		};
+
+		const action = setEditModelErrors(errors, entityId, sectionName, moduleName);
+		const newState = viewReducer(oldState, action);
+
+		return expect(newState, "to be", oldState).and("to equal", Immutable.fromJS({ edit: expected }));
+	});
 });

--- a/src/selectors/view.js
+++ b/src/selectors/view.js
@@ -1,6 +1,6 @@
 import { createSelector } from "reselect";
 import { selectCurrentModuleName } from "./navigation";
-import { isObjectContainsPropertyWithValue } from "./../utils/propertyHelper";
+import { isObjectContainsPropertyWithValue, isObjectContainsPropertyWithAnyValue } from "./../utils/propertyHelper";
 import { tryGetNewEntityIdKey } from "./../utils/urlHelper";
 
 const modulesData = state => state.get("view");
@@ -44,6 +44,33 @@ const getModifiedSectionsFromModule = (editData, moduleName, entityId) => {
 		}
 	}
 	return modifiedSections;
+};
+
+export const getSectionsWithErrors = entityId =>
+	createSelector(editData, selectCurrentModuleName, (data, moduleName) => {
+		return getSectionsWithErrorsFromModule(data, moduleName, entityId);
+	});
+
+const getSectionsWithErrorsFromModule = (editData, moduleName, entityId) => {
+	const errorSections = [];
+	if (editData != null) {
+		const dataJS = editData.toJS();
+		const sections = dataJS[moduleName]?.[entityId];
+		if (sections != null) {
+			const sectionsKeys = Object.keys(sections);
+			for (const sectionKey of sectionsKeys) {
+				const sectionModel = sections[sectionKey].model;
+
+				if (sectionModel != null) {
+					const hasError = isObjectContainsPropertyWithAnyValue(sectionModel, "error");
+					if (hasError === true) {
+						errorSections.push(sectionKey);
+					}
+				}
+			}
+		}
+	}
+	return errorSections;
 };
 
 export const getModifiedTabs = tabsParams =>

--- a/src/selectors/view.test.js
+++ b/src/selectors/view.test.js
@@ -1,5 +1,11 @@
 import Immutable from "immutable";
-import { isEntityUnderEditing, getModifiedSections, getModifiedModels, getModifiedTabs } from "./view";
+import {
+	isEntityUnderEditing,
+	getModifiedSections,
+	getModifiedModels,
+	getModifiedTabs,
+	getSectionsWithErrors,
+} from "./view";
 
 describe("isEntityUnderEditing", () => {
 	let state, stateWithEmptyEdit;
@@ -95,6 +101,62 @@ describe("getModifiedSections", () => {
 
 	it("Retrieves empty array if edit is missing from the store", () => {
 		expect(getModifiedSections, "when called with", ["id2"], "called with", [stateWithEmptyEdit], "to satisfy", []);
+	});
+});
+
+describe("getSectionsWithErrors", () => {
+	let state, stateWithEmptyEdit;
+	beforeEach(() => {
+		state = Immutable.fromJS({
+			view: {
+				edit: {
+					module1: {
+						id1: {
+							section1: {},
+							section2: {
+								model: {
+									field1: {
+										error: "smth",
+									},
+								},
+							},
+							section3: {
+								model: {
+									field1: {
+										value: "another",
+										wasModified: false,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			navigation: {
+				route: { match: { path: "/:scope/module1/id1/section1" } },
+				config: { prependPath: "/:scope/", prependHref: "/scope/" },
+			},
+		});
+
+		stateWithEmptyEdit = Immutable.fromJS({
+			view: {},
+			navigation: {
+				route: { match: { path: "/:scope/module1/id1/section1" } },
+				config: { prependPath: "/:scope/", prependHref: "/scope/" },
+			},
+		});
+	});
+
+	it("Retrieves sections with errors", () => {
+		expect(getSectionsWithErrors, "when called with", ["id1"], "called with", [state], "to satisfy", ["section2"]);
+	});
+
+	it("Retrieves empty array if no sections found or no sections were modified", () => {
+		expect(getSectionsWithErrors, "when called with", ["id2"], "called with", [state], "to satisfy", []);
+	});
+
+	it("Retrieves empty array if edit is missing from the store", () => {
+		expect(getSectionsWithErrors, "when called with", ["id2"], "called with", [stateWithEmptyEdit], "to satisfy", []);
 	});
 });
 

--- a/src/utils/propertyHelper.js
+++ b/src/utils/propertyHelper.js
@@ -49,3 +49,17 @@ export const isObjectContainsPropertyWithValue = (obj, propertyName, value) => {
 
 	return false;
 };
+
+export const isObjectContainsPropertyWithAnyValue = (obj, propertyName) => {
+	if (obj.hasOwnProperty(propertyName) && obj[propertyName]) {
+		return true;
+	}
+
+	for (let prop in obj) {
+		if (obj.hasOwnProperty(prop) && typeof obj[prop] === "object") {
+			if (isObjectContainsPropertyWithAnyValue(obj[prop], propertyName)) return true;
+		}
+	}
+
+	return false;
+};

--- a/src/utils/propertyHelper.test.js
+++ b/src/utils/propertyHelper.test.js
@@ -109,3 +109,39 @@ describe("isObjectContainsPropertyWithValue", () => {
 		expect(result, "to be false");
 	});
 });
+
+describe("isObjectContainsPropertyWithAnyValue", () => {
+	it("Returns true if object contains specified property with any value", () => {
+		const obj = {
+			prop1: {
+				a: {
+					m: "Hello",
+				},
+			},
+			prop2: {
+				m: "Hello Bobbina",
+			},
+		};
+
+		const result = propertyHelper.isObjectContainsPropertyWithAnyValue(obj, "m");
+
+		expect(result, "to be true");
+	});
+
+	it("Returns false if object does not contain specified property with any value", () => {
+		const obj = {
+			prop1: {
+				a: {
+					m: "Hello",
+				},
+			},
+			prop2: {
+				m: "Hello Bob",
+			},
+		};
+
+		const result = propertyHelper.isObjectContainsPropertyWithAnyValue(obj, "error");
+
+		expect(result, "to be false");
+	});
+});


### PR DESCRIPTION
[AB#43266](https://dev.azure.com/orckestra001/da965986-c85b-43be-9915-219568b000e5/_workitems/edit/43266)

- it is possibe to save error for model fields for  specific section so error can be displayed near the field
- when field change value - the error is cleared
- if section has any error, then it is higlighed like this (to be confirmed with designer)

![image](https://user-images.githubusercontent.com/6649972/105168439-cfe77400-5b22-11eb-9a87-80349b676a7a.png)
![section-with-error-edit](https://user-images.githubusercontent.com/6649972/105176062-6456d400-5b2d-11eb-8444-fe63b53a8ba8.gif)
