### PR TITLE
Update .az.yml for Azure Pipelines

### DIFF
--- a/.az.yml
+++ b/.az.yml
@@ -19,9 +19,9 @@ variables:
 
 steps:
 - task: NodeTool@0
-  displayName: 'Use Node 12.x'
+  displayName: 'Use Node 15.x'
   inputs:
-    versionSpec: 12.x
+    versionSpec: 15.x
 
 - task: Npm@1
   displayName: 'npm install'


### PR DESCRIPTION
Node version was updated to 15 since it uses npm 7.x which now installs peer deps automatically (that will save us from the issues when related packages adds some extra deps in new versions and our build getting failed after this).