### PR TITLE
Allow the entityId of a SegmentPage to be overridden

### DIFF
--- a/src/components/Routing/FullPage.js
+++ b/src/components/Routing/FullPage.js
@@ -3,7 +3,7 @@ import Page from "./Page";
 import SegmentPage from "./SegmentPage";
 
 const FullPage = ({ path, config, location, match, modulePrependPath }) => {
-	const { component, pages = {}, segments, subpages } = config;
+	const { component, pages = {}, segments, subpages, entityIdResolver } = config;
 	if (segments) {
 		return (
 			<SegmentPage
@@ -13,6 +13,7 @@ const FullPage = ({ path, config, location, match, modulePrependPath }) => {
 				location={location}
 				match={match}
 				modulePrependPath={modulePrependPath}
+				entityIdResolver={entityIdResolver}
 			/>
 		);
 	}

--- a/src/components/Routing/FullPage.test.js
+++ b/src/components/Routing/FullPage.test.js
@@ -112,4 +112,48 @@ describe("Fullpage", () => {
 			</Provider>,
 		);
 	});
+
+	it("entityIdResolver is passed to SegmentPage", () => {
+		const location = {
+			pathname: "/meep/snap/stuff",
+		};
+
+		const segments = { "/stuff": { component: View2, label: "Two" } };
+		const customResolver = () => "customId";
+
+		expect(
+			<Provider store={store}>
+				<MemoryRouter initialEntries={["/meep/snap"]}>
+					<div>
+						<FullPage
+							path="/meep/snap"
+							config={{
+								component: View1,
+								segments: segments,
+								entityIdResolver: customResolver,
+							}}
+							location={location}
+							match={match}
+						/>
+					</div>
+				</MemoryRouter>
+			</Provider>,
+			"when mounted",
+			"to satisfy",
+			<Provider store={store}>
+				<MemoryRouter initialEntries={["/meep/snap/stuff"]}>
+					<div>
+						<div id="view1"></div>
+						<SegmentPage
+							path="/:scope/snap"
+							location={location}
+							segments={segments}
+							match={match}
+							entityIdResolver={customResolver}
+						/>
+					</div>
+				</MemoryRouter>
+			</Provider>,
+		);
+	});
 });

--- a/src/components/Routing/SegmentPage.js
+++ b/src/components/Routing/SegmentPage.js
@@ -135,16 +135,24 @@ export const SegmentItem = ({ isModified, isError, isActive, segpath, config, ba
 	);
 };
 
-const SegmentPage = ({ path, component: View, segments, location, match, modulePrependPath }) => {
-	const pattern = new UrlPattern(path);
-	const baseHref = pattern.stringify(match.params);
-	const pages = [],
-		subpages = [];
+const defaultEntityIdResolver = ({ match, baseHref }) => {
 	const entityIdKey = Object.keys(match.params).find(p => p !== "scope");
 	let entityId = match.params[entityIdKey];
 	if (!entityId) {
 		entityId = tryGetNewEntityIdKey(baseHref);
 	}
+
+	return entityId;
+};
+
+const SegmentPage = ({ path, component: View, segments, location, match, modulePrependPath, entityIdResolver }) => {
+	const pattern = new UrlPattern(path);
+	const baseHref = pattern.stringify(match.params);
+	const pages = [],
+		subpages = [];
+
+	const entityIdResolverParams = { match, baseHref };
+	const entityId = (entityIdResolver ?? defaultEntityIdResolver)(entityIdResolverParams);
 
 	const modifiedSections = useSelector(getModifiedSections(entityId));
 	const sectionsWithErrors = useSelector(getSectionsWithErrors(entityId));

--- a/src/components/Routing/SegmentPage.test.js
+++ b/src/components/Routing/SegmentPage.test.js
@@ -364,4 +364,74 @@ describe("SegmentPage", () => {
 			}),
 		);
 	});
+
+	it("segment item is not flagged as modified because the entityId was overridden", () => {
+		const history = createMemoryHistory({
+			initialEntries: ["/foo/meep/entityIdValue"],
+		});
+		return expect(
+			<Provider store={store}>
+				<Router history={history}>
+					<ThemeProvider theme={{}}>
+						<I18n>
+							<SegmentPage
+								path="/:scope/meep/entityIdValue"
+								segments={segments}
+								match={{ params: { scope: "foo", entityId: "entityIdValue" } }}
+								location={{ pathname: "/foo/meep/entityIdValue" }}
+								entityIdResolver={() => "anotherId"}
+							/>
+						</I18n>
+					</ThemeProvider>
+				</Router>
+			</Provider>,
+			"when mounted",
+			"to satisfy",
+			<Wrapper>
+				<MemoryRouter>
+					<List>
+						<Item to="/foo/meep/entityIdValue/one">
+							<Grid container justify="space-between">
+								<Grid item>Text</Grid>
+								<Grid item></Grid>
+							</Grid>
+						</Item>
+						<Item to="/foo/meep/entityIdValue/two">
+							<Grid container justify="space-between">
+								<Grid item>Translated</Grid>
+								<Grid item></Grid>
+							</Grid>
+						</Item>
+						<Item to="/foo/meep/entityIdValue/three">
+							<Grid container justify="space-between">
+								<Grid item>
+									<TooltippedTypography children="ComponentLabel" titleValue="ComponentLabel" noWrap />
+								</Grid>
+								<Grid item>
+									<ComponentLabel />
+								</Grid>
+							</Grid>
+						</Item>
+						<Item>
+							<Grid container justify="space-between">
+								<Grid item>DisabledSection</Grid>
+								<Grid item></Grid>
+							</Grid>
+						</Item>
+						<Item>
+							<Grid container justify="space-between">
+								<Grid item>DisabledSectionBySelector</Grid>
+								<Grid item></Grid>
+							</Grid>
+						</Item>
+					</List>
+				</MemoryRouter>
+				<View1 />
+			</Wrapper>,
+		).then(() =>
+			expect(history, "to satisfy", {
+				location: { pathname: "/foo/meep/entityIdValue/one" },
+			}),
+		);
+	});
 });


### PR DESCRIPTION
This modifications allows the entityId of a SegmentPage to be overriden
from module.js. This was made to allow pages without Ids (order
settings) or pages with a different route pattern (providers) to work with
the edition framework already in place (useEditState).

 #25175