### PR TITLE
Add custom mapping capabilities to mapHelper

### DIFF
--- a/src/utils/mapHelper.js
+++ b/src/utils/mapHelper.js
@@ -12,17 +12,25 @@ export const mapModel = (model, initialModel, mappingRules = []) => {
 	// 		modelName: "modelName2",
 	// 		domainName: "domainName2"
 	// 	},
+	// 	{
+	// 		modelName: "modelName3",
+	// 		transform: (model, modelValue, result) => { /* Custom mapping code. */ }
+	// 	},
 	// ]
 	// if you don't need this - just don't pass any value for that parameter
 
 	const result = cloneDeep(initialModel);
 
-	const modifiedFeilds = Object.keys(model);
+	const modifiedFields = Object.keys(model);
 
-	modifiedFeilds.forEach(modifiedFeild => {
+	modifiedFields.forEach(modifiedFeild => {
 		const tempRule = mappingRules.find(rule => rule.modelName === modifiedFeild);
 		if (tempRule != null) {
-			result[tempRule.domainName] = model[tempRule.modelName].value;
+			if (tempRule.transform) {
+				tempRule.transform(model, model[tempRule.modelName].value, result);
+			} else {
+				result[tempRule.domainName] = model[tempRule.modelName].value;
+			}
 		} else {
 			result[modifiedFeild] = model[modifiedFeild].value;
 		}

--- a/src/utils/mapHelper.test.js
+++ b/src/utils/mapHelper.test.js
@@ -52,4 +52,27 @@ describe("mapModel", () => {
 
 		expect(resultModel, "to equal", expectedResultModel);
 	});
+
+	it("Maps using a custom mapper", () => {
+		const mapRules = [
+			{
+				modelName: "field2",
+				transform: (model, modelValue, result) => {
+					result.otherField = modelValue;
+				},
+			},
+		];
+
+		const resultModel = mapModel(model, initialModel, mapRules);
+
+		const expectedResultModel = {
+			field1: "Hello",
+			name: "Carl",
+			field3: false,
+			field4: "Prop to add",
+			otherField: "Bob",
+		};
+
+		expect(resultModel, "to equal", expectedResultModel);
+	});
 });


### PR DESCRIPTION
This adds a custom transform method for mapHelper. Some model have
a property mapped to more than one UI fields. This modification allow a
different mapping for these fields.
 #25175