### PR TITLE
Remove edit state if no modifications applied to the tab

### DIFF
--- a/src/components/MaterialUI/Navigation/TabBar.js
+++ b/src/components/MaterialUI/Navigation/TabBar.js
@@ -139,16 +139,20 @@ const MuiBar = ({ module, pages }) => {
 			setShowConfirmationModal(true);
 		} else {
 			closeCallback();
+			removeEditState(href, entityIdKey, path);
 		}
 	};
 
 	const closeTab = () => {
 		setShowConfirmationModal(false);
 		currentCloseData.closeCallback();
-		let newKey = tryGetNewEntityIdKey(currentCloseData.href);
-		const key =
-			currentCloseData.entityIdKey === newKey ? currentCloseData.entityIdKey : `:${currentCloseData.entityIdKey}`;
-		const entityId = getValueFromUrlByKey(currentCloseData.href, currentCloseData.path, key);
+		removeEditState(currentCloseData.href, currentCloseData.entityIdKey, currentCloseData.path);
+	};
+
+	const removeEditState = (href, entityIdKey, path) => {
+		let newKey = tryGetNewEntityIdKey(href);
+		const key = entityIdKey === newKey ? entityIdKey : `:${entityIdKey}`;
+		const entityId = getValueFromUrlByKey(href, path, key);
 		dispatch(removeEditNode, [entityId]);
 	};
 

--- a/src/components/MaterialUI/Navigation/TabBar.test.js
+++ b/src/components/MaterialUI/Navigation/TabBar.test.js
@@ -392,6 +392,11 @@ describe("TabBar", () => {
 			</TestWrapper>
 		);
 
+		const dispatchSpy = sinon.spy();
+		const useDispatchWithModulesDataStub = sinon
+			.stub(useDispatchWithModulesData, "useDispatchWithModulesData")
+			.returns(dispatchSpy);
+
 		const mountedComponent = mount(component);
 
 		const pageTab = mountedComponent.find(Tab).at(1);
@@ -400,6 +405,10 @@ describe("TabBar", () => {
 		closeIcon.simulate("click");
 
 		expect(pages[0].close, "was called");
+
+		expect(dispatchSpy, "to have a call satisfying", { args: [removeEditNode, [pages[0].params.entityId]] });
+
+		useDispatchWithModulesDataStub.restore();
 	});
 
 	it("Calls correct close callback when close icon for specific page tab is clicked and tab was modified", () => {


### PR DESCRIPTION
This PR will allow to remove validation results in cases like described in this bug.
https://dev.azure.com/orckestra001/OrckestraCommerce/_workitems/edit/44412/