### PR TITLE
Switch component to allow style override

### DIFF
--- a/src/components/MaterialUI/DataDisplay/PredefinedElements/ConfirmationModal.js
+++ b/src/components/MaterialUI/DataDisplay/PredefinedElements/ConfirmationModal.js
@@ -15,9 +15,6 @@ const useStyles = makeStyles(theme => ({
 		maxWidth: "480px",
 		wordWrap: "normal",
 	},
-	cancelButton: {
-		marginRight: theme.spacing(1),
-	},
 }));
 
 const ConfirmationModal = ({
@@ -48,10 +45,10 @@ const ConfirmationModal = ({
 
 	const actionPanel = (
 		<div className={classes.actionPanel}>
-			<Button className={classes.cancelButton} variant="outlined" onClick={() => cancelCallback()}>
+			<Button variant="outlined" onClick={() => cancelCallback()}>
 				<FormattedMessage {...cancelLabel} />
 			</Button>
-			<Button variant="contained" color="primary" onClick={() => okCallback()}>
+			<Button variant="contained" color="primary" onClick={() => okCallback()} disableElevation>
 				<FormattedMessage {...okLabel} />
 			</Button>
 		</div>

--- a/src/components/MaterialUI/DataDisplay/PredefinedElements/ConfirmationModal.test.js
+++ b/src/components/MaterialUI/DataDisplay/PredefinedElements/ConfirmationModal.test.js
@@ -38,7 +38,7 @@ describe("ConfirmationModal", () => {
 				<Button variant="outlined" onClick={() => cancelCallback()}>
 					{stringifyWithoutQuotes(messages["orc-shared.cancel"])}
 				</Button>
-				<Button variant="contained" color="primary" onClick={() => okCallback()}>
+				<Button variant="contained" color="primary" onClick={() => okCallback()} disableElevation>
 					{stringifyWithoutQuotes(messages["orc-shared.close"])}
 				</Button>
 			</div>

--- a/src/components/MaterialUI/DataDisplay/PredefinedElements/StepperModal.js
+++ b/src/components/MaterialUI/DataDisplay/PredefinedElements/StepperModal.js
@@ -16,9 +16,6 @@ const useStyles = makeStyles(theme => ({
 		height: theme.spacing(56),
 		wordWrap: "normal",
 	},
-	cancelButton: {
-		marginRight: theme.spacing(1),
-	},
 	step: {
 		position: "relative",
 		display: "inline-block",
@@ -121,21 +118,21 @@ const StepperModal = ({ steps = [], title = "", open, closeCallback, confirmCall
 	const actionPanel = (
 		<>
 			{!!currentStep && (
-				<Button variant="contained" color="primary" onClick={backClick}>
+				<Button variant="contained" color="primary" onClick={backClick} disableElevation>
 					<FormattedMessage {...sharedMessages.back} />
 				</Button>
 			)}
 			<div className={classes.actionPanel}>
-				<Button className={classes.cancelButton} variant="outlined" onClick={closeCallback}>
+				<Button variant="outlined" onClick={closeCallback}>
 					<FormattedMessage {...sharedMessages.cancel} />
 				</Button>
 				{currentStep < steps.length - 1 && (
-					<Button variant="contained" color="primary" onClick={nextClick}>
+					<Button variant="contained" color="primary" onClick={nextClick} disableElevation>
 						<FormattedMessage {...sharedMessages.next} />
 					</Button>
 				)}
 				{currentStep === steps.length - 1 && (
-					<Button variant="contained" color="primary" onClick={confirmCallback}>
+					<Button variant="contained" color="primary" onClick={confirmCallback} disableElevation>
 						{confirmTitle || <FormattedMessage {...sharedMessages.applyChanges} />}
 					</Button>
 				)}

--- a/src/components/MaterialUI/DataDisplay/PredefinedElements/StepperModal.test.js
+++ b/src/components/MaterialUI/DataDisplay/PredefinedElements/StepperModal.test.js
@@ -39,7 +39,7 @@ describe("StepperModal", () => {
 				<Button variant="outlined" onClick={() => cancelCallback()}>
 					{sharedMessages.cancel.defaultMessage}
 				</Button>
-				<Button variant="contained" color="primary" onClick={() => {}}>
+				<Button variant="contained" color="primary" onClick={() => {}} disableElevation>
 					{sharedMessages.next.defaultMessage}
 				</Button>
 			</div>

--- a/src/components/MaterialUI/DataDisplay/tableHelpers.js
+++ b/src/components/MaterialUI/DataDisplay/tableHelpers.js
@@ -69,6 +69,7 @@ const renderByType = (e, def, rowId, readOnly, transformedValue) => {
 			switchProps.set(SwitchProps.propNames.offCaption, def.switch?.offCaption);
 			switchProps.set(SwitchProps.propNames.readOnly, readOnly);
 			switchProps.set(SwitchProps.propNames.update, def.onChange);
+			switchProps.set(SwitchProps.propNames.className, def.switch?.className);
 
 			return transformedValue != null ? [<Switch data-row-id={rowId} switchProps={switchProps} />] : [null];
 

--- a/src/components/MaterialUI/Inputs/Switch.js
+++ b/src/components/MaterialUI/Inputs/Switch.js
@@ -89,16 +89,18 @@ const Switch = ({ switchProps }) => {
 	const offCaption = switchProps?.get(SwitchProps.propNames.offCaption);
 	const disabled = switchProps?.get(SwitchProps.propNames.disabled) || false;
 	const readOnly = switchProps?.get(SwitchProps.propNames.readOnly);
+	const className = switchProps?.get(SwitchProps.propNames.className) || "";
 
 	const formattedOnCaption = onCaption != null ? formatMessage(onCaption) : "";
 	const formattedOffCaption = offCaption != null ? formatMessage(offCaption) : "";
 
 	const classes = useStyles({ formattedOnCaption, formattedOffCaption, readOnly });
+	const switchClasses = { ...classes, ...className };
 
 	return (
 		<SwitchMui
 			disabled={disabled}
-			classes={classes}
+			classes={switchClasses}
 			checked={value}
 			onChange={e => (!readOnly ? update(e.target.checked) : null)}
 			color={"primary"}

--- a/src/components/MaterialUI/Inputs/SwitchProps.js
+++ b/src/components/MaterialUI/Inputs/SwitchProps.js
@@ -8,6 +8,7 @@ class SwitchProps extends ComponentProps {
 		offCaption: "offCaption",
 		disabled: "disabled",
 		readOnly: "readOnly",
+		className: "className",
 	};
 
 	constructor() {
@@ -18,6 +19,7 @@ class SwitchProps extends ComponentProps {
 		this.componentProps.set(this.constructor.propNames.offCaption, null);
 		this.componentProps.set(this.constructor.propNames.disabled, null);
 		this.componentProps.set(this.constructor.propNames.readOnly, null);
+		this.componentProps.set(this.constructor.propNames.className, null);
 
 		this._isSwitchProps = true;
 	}

--- a/src/components/MaterialUI/Inputs/SwitchProps.test.js
+++ b/src/components/MaterialUI/Inputs/SwitchProps.test.js
@@ -2,13 +2,13 @@ import SwitchProps, { isSwitchProps } from "./SwitchProps";
 
 describe("Switch Props", () => {
 	it("Contains necessary props keys", () => {
-		const propNames = ["update", "value", "onCaption", "offCaption", "disabled", "readOnly"];
+		const propNames = ["update", "value", "onCaption", "offCaption", "disabled", "readOnly", "className"];
 
 		expect(SwitchProps.propNames, "to have keys", propNames);
 	});
 
 	it("Puts keys in component props map", () => {
-		const propNames = ["update", "value", "onCaption", "offCaption", "disabled", "readOnly"];
+		const propNames = ["update", "value", "onCaption", "offCaption", "disabled", "readOnly", "className"];
 
 		const switchProps = new SwitchProps();
 

--- a/src/components/MaterialUI/muiThemes.js
+++ b/src/components/MaterialUI/muiThemes.js
@@ -272,6 +272,7 @@ const setThemeOverrides = theme => ({
 		containedPrimary: {
 			color: theme.palette.primary.contrastText,
 			backgroundColor: theme.palette.primary.main,
+			border: "none",
 			"&:hover": {
 				backgroundColor: theme.palette.primary.dark,
 				// Reset on touch devices, it doesn't add specificity

--- a/src/components/Scope/Scope.test.js
+++ b/src/components/Scope/Scope.test.js
@@ -122,7 +122,7 @@ describe("ScopeBar", () => {
 		const expected = (
 			<div>
 				<div>
-					<Button variant="outlined" color="primary" onClick={() => updateViewState("show", true)}>
+					<Button variant="outlined" color="primary" onClick={() => updateViewState("show", true)} disableElevation>
 						<TooltippedTypography noWrap children="Scope name" titleValue="Scope name" />
 					</Button>
 				</div>
@@ -138,7 +138,13 @@ describe("ScopeBar", () => {
 		const expected = (
 			<div>
 				<div>
-					<Button disabled variant="outlined" color="primary" onClick={() => updateViewState("show", true)}>
+					<Button
+						disabled
+						variant="outlined"
+						color="primary"
+						onClick={() => updateViewState("show", true)}
+						disableElevation
+					>
 						<TooltippedTypography noWrap children="Scope name" titleValue="Scope name" />
 					</Button>
 				</div>
@@ -154,7 +160,7 @@ describe("ScopeBar", () => {
 		const expected = (
 			<div>
 				<div>
-					<Button variant="contained" color="primary" onClick={() => updateViewState("show", true)}>
+					<Button variant="contained" color="primary" onClick={() => updateViewState("show", true)} disableElevation>
 						<TooltippedTypography noWrap children="Scope name" titleValue="Scope name" />
 					</Button>
 				</div>

--- a/src/components/Scope/index.js
+++ b/src/components/Scope/index.js
@@ -53,10 +53,10 @@ export const ScopeBar = ({ show, name, updateViewState, disabled }) => {
 			<div className={classes.buttonContainer}>
 				<Button
 					disabled={disabled}
-					classes={{ root: classes.scopeButton, outlined: classes.outlinedButton }}
 					variant={variant}
 					color="primary"
 					onClick={() => updateViewState("show", true)}
+					disableElevation
 				>
 					<TooltippedTypography noWrap children={name} titleValue={name} />
 				</Button>


### PR DESCRIPTION
Allow Switch component wrapper to accept style overrides to allow customization from anywhere
Standardized the code used for the action buttons (create order, create customer, etc ..)