### PR TITLE
Disable onMouseDown event on LoadingScreen component

### DIFF
--- a/src/components/MaterialUI/Feedback/loadingScreen.js
+++ b/src/components/MaterialUI/Feedback/loadingScreen.js
@@ -14,6 +14,12 @@ const useStyles = makeStyles(theme => ({
 	},
 }));
 
+const onMouseDownHandler = event => {
+	// We want to disable clicking on the bakdrop, as it causes strange user selections to occur
+	event.preventDefault();
+	event.stopPropagation();
+};
+
 const LoadingScreen = () => {
 	const classes = useStyles();
 	const loadingScreen = useSelector(requestRunningSelector);
@@ -29,7 +35,7 @@ const LoadingScreen = () => {
 	}, [loadingScreen, setProgressState]);
 
 	return (
-		<Backdrop className={classes.backdrop} invisible={true} open={loadingScreen}>
+		<Backdrop className={classes.backdrop} invisible={true} open={loadingScreen} onMouseDown={onMouseDownHandler}>
 			{progressState && <CircularProgress className={classes.progress} size={100} color="inherit" />}
 		</Backdrop>
 	);

--- a/src/components/MaterialUI/Feedback/loadingScreen.js
+++ b/src/components/MaterialUI/Feedback/loadingScreen.js
@@ -15,7 +15,7 @@ const useStyles = makeStyles(theme => ({
 }));
 
 const onMouseDownHandler = event => {
-	// We want to disable clicking on the bakdrop, as it causes strange user selections to occur
+	// We want to disable clicking on the backdrop, as it causes strange user selections to occur
 	event.preventDefault();
 	event.stopPropagation();
 };
@@ -35,7 +35,13 @@ const LoadingScreen = () => {
 	}, [loadingScreen, setProgressState]);
 
 	return (
-		<Backdrop className={classes.backdrop} invisible={true} open={loadingScreen} onMouseDown={onMouseDownHandler}>
+		<Backdrop
+			data-qa={"backdroploadingscreen"}
+			className={classes.backdrop}
+			invisible={true}
+			open={loadingScreen}
+			onMouseDown={onMouseDownHandler}
+		>
 			{progressState && <CircularProgress className={classes.progress} size={100} color="inherit" />}
 		</Backdrop>
 	);

--- a/src/components/MaterialUI/Feedback/loadingScreen.test.js
+++ b/src/components/MaterialUI/Feedback/loadingScreen.test.js
@@ -4,7 +4,7 @@ import LoadingScreen from "./loadingScreen";
 import Backdrop from "@material-ui/core/Backdrop";
 import { act } from "react-dom/test-utils";
 import CircularProgress from "@material-ui/core/CircularProgress";
-import { createMuiTheme, firstItemComparator, TestWrapper } from "../../../utils/testUtils";
+import { createMuiTheme, TestWrapper } from "../../../utils/testUtils";
 import Immutable from "immutable";
 import sinon from "sinon";
 import { mount } from "enzyme";

--- a/src/components/MaterialUI/Feedback/loadingScreen.test.js
+++ b/src/components/MaterialUI/Feedback/loadingScreen.test.js
@@ -4,9 +4,10 @@ import LoadingScreen from "./loadingScreen";
 import Backdrop from "@material-ui/core/Backdrop";
 import { act } from "react-dom/test-utils";
 import CircularProgress from "@material-ui/core/CircularProgress";
-import { createMuiTheme, TestWrapper } from "../../../utils/testUtils";
+import { createMuiTheme, firstItemComparator, TestWrapper } from "../../../utils/testUtils";
 import Immutable from "immutable";
 import sinon from "sinon";
+import { mount } from "enzyme";
 
 describe("loadingScreen", () => {
 	let store, state;
@@ -109,5 +110,27 @@ describe("loadingScreen", () => {
 			document.body.removeChild(menuNode);
 			clock.restore();
 		}
+	});
+
+	it("Handles the onMouseDown event without error", () => {
+		state = state.setIn(["requests", "actives", "aRequest"], true);
+
+		const component = (
+			<TestWrapper stylesProvider muiThemeProvider={{ theme }} provider={{ store }}>
+				<LoadingScreen />
+			</TestWrapper>
+		);
+
+		const mountedComponent = mount(component);
+		const backdrop = mountedComponent.find("[data-qa='backdroploadingscreen']").first();
+
+		const event = {
+			preventDefault: jest.fn(),
+			stopPropagation: jest.fn(),
+		};
+		backdrop.invoke("onMouseDown")(event);
+
+		expect(event.preventDefault.mock.calls.length, "to equal", 1);
+		expect(event.stopPropagation.mock.calls.length, "to equal", 1);
 	});
 });


### PR DESCRIPTION
Disable onMouseDown event on LoadingScreen component, as it causes strange text selections to occur on double/triple clicks.

Story ABC#45519