### PR TITLE
Added a generic action modal component to support more than two buttons.

### DIFF
--- a/src/components/MaterialUI/DataDisplay/Modal.js
+++ b/src/components/MaterialUI/DataDisplay/Modal.js
@@ -20,7 +20,7 @@ const useStyles = makeStyles(theme => ({
 		},
 	},
 	containerNormal: {
-		minWidth: theme.spacing(48),
+		width: theme.spacing(48),
 	},
 	containerWide: {
 		width: theme.spacing(106.4),

--- a/src/components/MaterialUI/DataDisplay/PredefinedElements/ActionModal.js
+++ b/src/components/MaterialUI/DataDisplay/PredefinedElements/ActionModal.js
@@ -3,17 +3,12 @@ import Modal from "./../Modal";
 import ModalProps from "./../modalProps";
 import Button from "@material-ui/core/Button";
 import { makeStyles } from "@material-ui/core/styles";
-import Typography from "@material-ui/core/Typography";
 import sharedMessages from "../../../../sharedMessages";
 import { FormattedMessage } from "react-intl";
 
 const useStyles = makeStyles(theme => ({
 	actionPanel: {
 		float: "right",
-	},
-	message: {
-		maxWidth: "480px",
-		wordWrap: "normal",
 	},
 }));
 
@@ -29,11 +24,6 @@ const ActionModal = ({
 	const modalProps = new ModalProps();
 
 	const titleComponent = title || <FormattedMessage {...sharedMessages.confirmation} />;
-	const messageComponent = (
-		<div className={classes.message}>
-			<Typography children={message} />
-		</div>
-	);
 
 	modalProps.set(ModalProps.propNames.title, titleComponent);
 	modalProps.set(ModalProps.propNames.open, open);
@@ -57,7 +47,7 @@ const ActionModal = ({
 
 	modalProps.set(ModalProps.propNames.actionPanel, actionPanel);
 
-	return <Modal message={messageComponent} modalProps={modalProps} />;
+	return <Modal message={message} modalProps={modalProps} />;
 };
 
 export default ActionModal;

--- a/src/components/MaterialUI/DataDisplay/PredefinedElements/ActionModal.js
+++ b/src/components/MaterialUI/DataDisplay/PredefinedElements/ActionModal.js
@@ -1,0 +1,63 @@
+import React from "react";
+import Modal from "./../Modal";
+import ModalProps from "./../modalProps";
+import Button from "@material-ui/core/Button";
+import { makeStyles } from "@material-ui/core/styles";
+import Typography from "@material-ui/core/Typography";
+import sharedMessages from "../../../../sharedMessages";
+import { FormattedMessage } from "react-intl";
+
+const useStyles = makeStyles(theme => ({
+	actionPanel: {
+		float: "right",
+	},
+	message: {
+		maxWidth: "480px",
+		wordWrap: "normal",
+	},
+}));
+
+const ActionModal = ({
+	title,
+	message,
+	open,
+	actions, // Array of objects containing three properties: label, handler, isPrimary
+	backdropClickCallback,
+}) => {
+	const classes = useStyles();
+
+	const modalProps = new ModalProps();
+
+	const titleComponent = title || <FormattedMessage {...sharedMessages.confirmation} />;
+	const messageComponent = (
+		<div className={classes.message}>
+			<Typography children={message} />
+		</div>
+	);
+
+	modalProps.set(ModalProps.propNames.title, titleComponent);
+	modalProps.set(ModalProps.propNames.open, open);
+	modalProps.set(ModalProps.propNames.backdropClickCallback, backdropClickCallback);
+
+	const actionPanel = (
+		<div className={classes.actionPanel}>
+			{actions.map(action => (
+				<Button
+					key={action.label.id}
+					variant={action.isPrimary ? "contained" : "outlined"}
+					color={action.isPrimary ? "primary" : "default"}
+					disableElevation={action.isPrimary}
+					onClick={e => action.handler(e)}
+				>
+					<FormattedMessage {...action.label} />
+				</Button>
+			))}
+		</div>
+	);
+
+	modalProps.set(ModalProps.propNames.actionPanel, actionPanel);
+
+	return <Modal message={messageComponent} modalProps={modalProps} />;
+};
+
+export default ActionModal;

--- a/src/components/MaterialUI/DataDisplay/PredefinedElements/ActionModal.test.js
+++ b/src/components/MaterialUI/DataDisplay/PredefinedElements/ActionModal.test.js
@@ -1,0 +1,164 @@
+import React from "react";
+import Modal from "./../Modal";
+import ModalProps from "./../modalProps";
+import Typography from "@material-ui/core/Typography";
+import Button from "@material-ui/core/Button";
+import { mount } from "enzyme";
+import sinon from "sinon";
+import { IntlProvider } from "react-intl";
+import { extractMessages } from "./../../../../utils/testUtils";
+import sharedMessages from "./../../../../sharedMessages";
+import { stringifyWithoutQuotes } from "./../../../../utils/parseHelper";
+import ActionModal from "./ActionModal";
+
+const messages = extractMessages(sharedMessages);
+
+describe("ActionModal", () => {
+	it("Renders ActionModal correctly", () => {
+		const open = true;
+		const message = "message";
+
+		const actionOne = { label: sharedMessages.yes, handler: jest.fn(), isPrimary: true };
+		const actionTwo = { label: sharedMessages.no, handler: jest.fn() };
+		const actionThree = { label: sharedMessages.cancel, handler: jest.fn() };
+
+		const backdropClickCallback = jest.fn();
+		const modalProps = new ModalProps();
+
+		const titleComponent = stringifyWithoutQuotes(messages["orc-shared.confirmation"]);
+		const messageComponent = (
+			<div>
+				<Typography children={message} />
+			</div>
+		);
+
+		modalProps.set(ModalProps.propNames.title, titleComponent);
+		modalProps.set(ModalProps.propNames.open, open);
+		modalProps.set(ModalProps.propNames.backdropClickCallback, backdropClickCallback);
+
+		const actionPanel = (
+			<div>
+				<Button key="1" variant="contained" color="primary" onClick={() => actionOne.handler()} disableElevation>
+					{stringifyWithoutQuotes(messages["orc-shared.yes"])}
+				</Button>
+				<Button key="2" variant="outlined" onClick={() => actionTwo.handler()}>
+					{stringifyWithoutQuotes(messages["orc-shared.no"])}
+				</Button>
+				<Button key="3" variant="outlined" onClick={() => actionThree.handler()}>
+					{stringifyWithoutQuotes(messages["orc-shared.cancel"])}
+				</Button>
+			</div>
+		);
+
+		modalProps.set(ModalProps.propNames.actionPanel, actionPanel);
+
+		const component = (
+			<IntlProvider locale="en-US" messages={messages}>
+				<ActionModal
+					message={message}
+					open={open}
+					actions={[actionOne, actionTwo, actionThree]}
+					backdropClickCallback={backdropClickCallback}
+				/>
+			</IntlProvider>
+		);
+
+		const expected = (
+			<IntlProvider locale="en-US" messages={messages}>
+				<Modal message={messageComponent} modalProps={modalProps} />
+			</IntlProvider>
+		);
+
+		expect(component, "when mounted", "to satisfy", expected);
+	});
+
+	it("Renders ConfirmationModal correctly with non default title", () => {
+		const open = true;
+		const title = "aTitle";
+		const message = "aMessage";
+
+		const actionOne = { label: sharedMessages.about, handler: jest.fn() };
+		const actionTwo = { label: sharedMessages.help, handler: jest.fn(), isPrimary: true };
+		const actionThree = { label: sharedMessages.signOut, handler: jest.fn() };
+
+		const backdropClickCallback = jest.fn();
+		const modalProps = new ModalProps();
+
+		const messageComponent = (
+			<div>
+				<Typography children={message} />
+			</div>
+		);
+
+		modalProps.set(ModalProps.propNames.title, title);
+		modalProps.set(ModalProps.propNames.open, open);
+		modalProps.set(ModalProps.propNames.backdropClickCallback, backdropClickCallback);
+
+		const actionPanel = (
+			<div>
+				<Button key="1" variant="outlined" onClick={() => actionTwo.handler()}>
+					{stringifyWithoutQuotes(messages["orc-shared.about"])}
+				</Button>
+				<Button key="2" variant="contained" color="primary" onClick={() => actionOne.handler()} disableElevation>
+					{stringifyWithoutQuotes(messages["orc-shared.help"])}
+				</Button>
+				<Button key="3" variant="outlined" onClick={() => actionThree.handler()}>
+					{stringifyWithoutQuotes(messages["orc-shared.signOut"])}
+				</Button>
+			</div>
+		);
+
+		modalProps.set(ModalProps.propNames.actionPanel, actionPanel);
+
+		const component = (
+			<IntlProvider locale="en-US" messages={messages}>
+				<ActionModal
+					title={title}
+					message={message}
+					open={open}
+					actions={[actionOne, actionTwo, actionThree]}
+					backdropClickCallback={backdropClickCallback}
+				/>
+			</IntlProvider>
+		);
+
+		const expected = (
+			<IntlProvider locale="en-US" messages={messages}>
+				<Modal message={messageComponent} modalProps={modalProps} />
+			</IntlProvider>
+		);
+
+		expect(component, "when mounted", "to satisfy", expected);
+	});
+
+	it("Calls action handlers when buttons are pressed", () => {
+		const open = true;
+
+		const actionOne = { label: sharedMessages.yes, handler: sinon.spy(), isPrimary: true };
+		const actionTwo = { label: sharedMessages.no, handler: sinon.spy() };
+		const actionThree = { label: sharedMessages.cancel, handler: sinon.spy() };
+
+		const component = (
+			<IntlProvider locale="en-US" messages={messages}>
+				<ActionModal open={open} actions={[actionOne, actionTwo, actionThree]} />
+			</IntlProvider>
+		);
+
+		const mountedComponent = mount(component);
+
+		const buttons = mountedComponent.find(Button);
+
+		buttons.at(0).invoke("onClick")();
+		buttons.at(0).invoke("onClick")();
+		buttons.at(0).invoke("onClick")();
+
+		buttons.at(1).invoke("onClick")();
+		buttons.at(1).invoke("onClick")();
+
+		buttons.at(2).invoke("onClick")();
+
+		expect(actionOne.handler, "was called thrice");
+		expect(actionTwo.handler, "was called twice");
+		expect(actionThree.handler, "was called once");
+	});
+});

--- a/src/components/MaterialUI/DataDisplay/PredefinedElements/ActionModal.test.js
+++ b/src/components/MaterialUI/DataDisplay/PredefinedElements/ActionModal.test.js
@@ -26,11 +26,6 @@ describe("ActionModal", () => {
 		const modalProps = new ModalProps();
 
 		const titleComponent = stringifyWithoutQuotes(messages["orc-shared.confirmation"]);
-		const messageComponent = (
-			<div>
-				<Typography children={message} />
-			</div>
-		);
 
 		modalProps.set(ModalProps.propNames.title, titleComponent);
 		modalProps.set(ModalProps.propNames.open, open);
@@ -65,7 +60,7 @@ describe("ActionModal", () => {
 
 		const expected = (
 			<IntlProvider locale="en-US" messages={messages}>
-				<Modal message={messageComponent} modalProps={modalProps} />
+				<Modal message={message} modalProps={modalProps} />
 			</IntlProvider>
 		);
 
@@ -83,12 +78,6 @@ describe("ActionModal", () => {
 
 		const backdropClickCallback = jest.fn();
 		const modalProps = new ModalProps();
-
-		const messageComponent = (
-			<div>
-				<Typography children={message} />
-			</div>
-		);
 
 		modalProps.set(ModalProps.propNames.title, title);
 		modalProps.set(ModalProps.propNames.open, open);
@@ -124,7 +113,7 @@ describe("ActionModal", () => {
 
 		const expected = (
 			<IntlProvider locale="en-US" messages={messages}>
-				<Modal message={messageComponent} modalProps={modalProps} />
+				<Modal message={message} modalProps={modalProps} />
 			</IntlProvider>
 		);
 

--- a/src/components/MaterialUI/DataDisplay/PredefinedElements/ActionModal.test.js
+++ b/src/components/MaterialUI/DataDisplay/PredefinedElements/ActionModal.test.js
@@ -1,7 +1,6 @@
 import React from "react";
 import Modal from "./../Modal";
 import ModalProps from "./../modalProps";
-import Typography from "@material-ui/core/Typography";
 import Button from "@material-ui/core/Button";
 import { mount } from "enzyme";
 import sinon from "sinon";

--- a/src/components/MaterialUI/DataDisplay/PredefinedElements/ConfirmationModal.js
+++ b/src/components/MaterialUI/DataDisplay/PredefinedElements/ConfirmationModal.js
@@ -1,21 +1,6 @@
 import React from "react";
-import Modal from "./../Modal";
-import ModalProps from "./../modalProps";
-import Button from "@material-ui/core/Button";
-import { makeStyles } from "@material-ui/core/styles";
-import Typography from "@material-ui/core/Typography";
 import sharedMessages from "../../../../sharedMessages";
-import { FormattedMessage } from "react-intl";
-
-const useStyles = makeStyles(theme => ({
-	actionPanel: {
-		float: "right",
-	},
-	message: {
-		maxWidth: "480px",
-		wordWrap: "normal",
-	},
-}));
+import ActionModal from "./ActionModal";
 
 const ConfirmationModal = ({
 	title,
@@ -27,37 +12,23 @@ const ConfirmationModal = ({
 	okButtonLabel,
 	cancelButtonLabel,
 }) => {
-	const classes = useStyles();
-	const okLabel = okButtonLabel ?? sharedMessages.close;
 	const cancelLabel = cancelButtonLabel ?? sharedMessages.cancel;
+	const okLabel = okButtonLabel ?? sharedMessages.close;
 
-	const modalProps = new ModalProps();
+	const actions = [
+		{ label: cancelLabel, handler: cancelCallback },
+		{ label: okLabel, handler: okCallback, isPrimary: true },
+	];
 
-	const titleComponent = title || <FormattedMessage {...sharedMessages.confirmation} />;
-	const messageComponent = (
-		<div className={classes.message}>
-			<Typography children={message} />
-		</div>
+	return (
+		<ActionModal
+			title={title}
+			message={message}
+			open={open}
+			actions={actions}
+			backdropClickCallback={backdropClickCallback}
+		/>
 	);
-
-	modalProps.set(ModalProps.propNames.title, titleComponent);
-	modalProps.set(ModalProps.propNames.open, open);
-	modalProps.set(ModalProps.propNames.backdropClickCallback, backdropClickCallback);
-
-	const actionPanel = (
-		<div className={classes.actionPanel}>
-			<Button variant="outlined" onClick={e => cancelCallback(e)}>
-				<FormattedMessage {...cancelLabel} />
-			</Button>
-			<Button variant="contained" color="primary" onClick={e => okCallback(e)} disableElevation>
-				<FormattedMessage {...okLabel} />
-			</Button>
-		</div>
-	);
-
-	modalProps.set(ModalProps.propNames.actionPanel, actionPanel);
-
-	return <Modal message={messageComponent} modalProps={modalProps} />;
 };
 
 export default ConfirmationModal;

--- a/src/components/MaterialUI/DataDisplay/PredefinedElements/ConfirmationModal.test.js
+++ b/src/components/MaterialUI/DataDisplay/PredefinedElements/ConfirmationModal.test.js
@@ -1,15 +1,9 @@
 import React from "react";
 import ConfirmationModal from "./ConfirmationModal";
-import Modal from "./../Modal";
-import ModalProps from "./../modalProps";
-import Typography from "@material-ui/core/Typography";
-import Button from "@material-ui/core/Button";
-import { mount } from "enzyme";
-import sinon from "sinon";
 import { IntlProvider } from "react-intl";
 import { extractMessages } from "./../../../../utils/testUtils";
 import sharedMessages from "./../../../../sharedMessages";
-import { stringifyWithoutQuotes } from "./../../../../utils/parseHelper";
+import ActionModal from "./ActionModal";
 
 const messages = extractMessages(sharedMessages);
 
@@ -20,31 +14,11 @@ describe("ConfirmationModal", () => {
 		const backdropClickCallback = jest.fn();
 		const okCallback = jest.fn();
 		const cancelCallback = jest.fn();
-		const modalProps = new ModalProps();
 
-		const titleComponent = stringifyWithoutQuotes(messages["orc-shared.confirmation"]);
-		const messageComponent = (
-			<div>
-				<Typography children={message} />
-			</div>
-		);
-
-		modalProps.set(ModalProps.propNames.title, titleComponent);
-		modalProps.set(ModalProps.propNames.open, open);
-		modalProps.set(ModalProps.propNames.backdropClickCallback, backdropClickCallback);
-
-		const actionPanel = (
-			<div>
-				<Button variant="outlined" onClick={() => cancelCallback()}>
-					{stringifyWithoutQuotes(messages["orc-shared.cancel"])}
-				</Button>
-				<Button variant="contained" color="primary" onClick={() => okCallback()} disableElevation>
-					{stringifyWithoutQuotes(messages["orc-shared.close"])}
-				</Button>
-			</div>
-		);
-
-		modalProps.set(ModalProps.propNames.actionPanel, actionPanel);
+		const actions = [
+			{ label: sharedMessages.cancel, handler: cancelCallback },
+			{ label: sharedMessages.close, handler: okCallback, isPrimary: true },
+		];
 
 		const component = (
 			<IntlProvider locale="en-US" messages={messages}>
@@ -60,92 +34,26 @@ describe("ConfirmationModal", () => {
 
 		const expected = (
 			<IntlProvider locale="en-US" messages={messages}>
-				<Modal message={messageComponent} modalProps={modalProps} />
+				<ActionModal open={open} message={message} actions={actions} />
 			</IntlProvider>
 		);
 
 		expect(component, "when mounted", "to satisfy", expected);
-	});
-
-	it("Calls cancelCallback when cancel button is pressed", () => {
-		const open = true;
-		const cancelCallbackSpy = sinon.spy();
-		const modalProps = new ModalProps();
-
-		modalProps.set(ModalProps.propNames.open, open);
-
-		const component = (
-			<IntlProvider locale="en-US" messages={messages}>
-				<ConfirmationModal open={open} cancelCallback={cancelCallbackSpy} />
-			</IntlProvider>
-		);
-
-		const mountedComponent = mount(component);
-
-		const cancelButton = mountedComponent.find(Button).at(0);
-
-		cancelButton.invoke("onClick")();
-
-		expect(cancelCallbackSpy, "was called");
-	});
-
-	it("Calls okCallback when ok button is pressed", () => {
-		const open = true;
-		const okCallbackSpy = sinon.spy();
-		const modalProps = new ModalProps();
-
-		modalProps.set(ModalProps.propNames.open, open);
-
-		const component = (
-			<IntlProvider locale="en-US" messages={messages}>
-				<ConfirmationModal open={open} okCallback={okCallbackSpy} />
-			</IntlProvider>
-		);
-
-		const mountedComponent = mount(component);
-
-		const okButton = mountedComponent.find(Button).at(1);
-
-		okButton.invoke("onClick")();
-
-		expect(okCallbackSpy, "was called");
 	});
 
 	it("Renders ConfirmationModal correctly when set buttons' labels", () => {
 		const open = true;
 		const message = "message";
-		const okButtonlabel = sharedMessages.yes;
-		const cancelButtonlabel = sharedMessages.no;
 		const backdropClickCallback = jest.fn();
 		const okCallback = jest.fn();
 		const cancelCallback = jest.fn();
-		const modalProps = new ModalProps();
+		const okButtonLabel = sharedMessages.yes;
+		const cancelButtonLabel = sharedMessages.no;
 
-		const titleComponent = stringifyWithoutQuotes(messages["orc-shared.confirmation"]);
-		const okButtonlabelComponent = stringifyWithoutQuotes(messages["orc-shared.yes"]);
-		const cancelButtonlabelComponent = stringifyWithoutQuotes(messages["orc-shared.no"]);
-		const messageComponent = (
-			<div>
-				<Typography children={message} />
-			</div>
-		);
-
-		modalProps.set(ModalProps.propNames.title, titleComponent);
-		modalProps.set(ModalProps.propNames.open, open);
-		modalProps.set(ModalProps.propNames.backdropClickCallback, backdropClickCallback);
-
-		const actionPanel = (
-			<div>
-				<Button variant="outlined" onClick={() => cancelCallback()}>
-					{cancelButtonlabelComponent}
-				</Button>
-				<Button variant="contained" color="primary" onClick={() => okCallback()} disableElevation>
-					{okButtonlabelComponent}
-				</Button>
-			</div>
-		);
-
-		modalProps.set(ModalProps.propNames.actionPanel, actionPanel);
+		const actions = [
+			{ label: cancelButtonLabel, handler: cancelCallback },
+			{ label: okButtonLabel, handler: okCallback, isPrimary: true },
+		];
 
 		const component = (
 			<IntlProvider locale="en-US" messages={messages}>
@@ -154,62 +62,8 @@ describe("ConfirmationModal", () => {
 					open={open}
 					okCallback={okCallback}
 					cancelCallback={cancelCallback}
-					backdropClickCallback={backdropClickCallback}
-					okButtonLabel={okButtonlabel}
-					cancelButtonLabel={cancelButtonlabel}
-				/>
-			</IntlProvider>
-		);
-
-		const expected = (
-			<IntlProvider locale="en-US" messages={messages}>
-				<Modal message={messageComponent} modalProps={modalProps} />
-			</IntlProvider>
-		);
-
-		expect(component, "when mounted", "to satisfy", expected);
-	});
-
-	it("Renders ConfirmationModal correctly with non default title", () => {
-		const open = true;
-		const title = "title";
-		const message = "message";
-		const backdropClickCallback = jest.fn();
-		const okCallback = jest.fn();
-		const cancelCallback = jest.fn();
-		const modalProps = new ModalProps();
-
-		const messageComponent = (
-			<div>
-				<Typography children={message} />
-			</div>
-		);
-
-		modalProps.set(ModalProps.propNames.title, title);
-		modalProps.set(ModalProps.propNames.open, open);
-		modalProps.set(ModalProps.propNames.backdropClickCallback, backdropClickCallback);
-
-		const actionPanel = (
-			<div>
-				<Button variant="outlined" onClick={() => cancelCallback()}>
-					{stringifyWithoutQuotes(messages["orc-shared.cancel"])}
-				</Button>
-				<Button variant="contained" color="primary" onClick={() => okCallback()} disableElevation>
-					{stringifyWithoutQuotes(messages["orc-shared.close"])}
-				</Button>
-			</div>
-		);
-
-		modalProps.set(ModalProps.propNames.actionPanel, actionPanel);
-
-		const component = (
-			<IntlProvider locale="en-US" messages={messages}>
-				<ConfirmationModal
-					title={title}
-					message={message}
-					open={open}
-					okCallback={okCallback}
-					cancelCallback={cancelCallback}
+					okButtonLabel={okButtonLabel}
+					cancelButtonLabel={cancelButtonLabel}
 					backdropClickCallback={backdropClickCallback}
 				/>
 			</IntlProvider>
@@ -217,7 +71,7 @@ describe("ConfirmationModal", () => {
 
 		const expected = (
 			<IntlProvider locale="en-US" messages={messages}>
-				<Modal message={messageComponent} modalProps={modalProps} />
+				<ActionModal open={open} message={message} actions={actions} />
 			</IntlProvider>
 		);
 


### PR DESCRIPTION
- Added a generic action modal component to support more than two buttons.
- Adjusted confimationModal to use the new one instead of being a breaking change.

Story: #43800