### PR TITLE
Allow radio group to only have one option

### DIFF
--- a/src/components/MaterialUI/Inputs/Radio.js
+++ b/src/components/MaterialUI/Inputs/Radio.js
@@ -54,9 +54,14 @@ const extractAndValidateProps = radioProps => {
 	const row = radioProps.get(RadioProps.propNames.row) ?? true;
 	const radios = radioProps.get(RadioProps.propNames.radios);
 	const disabled = radioProps.get(RadioProps.propNames.disabled) ?? false;
+	const allowSingleRadio = radioProps.get(RadioProps.propNames.allowSingleRadio) ?? false;
 
-	if (!radios || radios.length < 2) {
+	if (!radios || (radios.length < 2 && !allowSingleRadio)) {
 		throw new Error("Radio component must have at least two options");
+	}
+
+	if (radios.length < 1) {
+		throw new Error("Radio component must have at least one option");
 	}
 
 	if (!name || name.length === 0) {

--- a/src/components/MaterialUI/Inputs/Radio.test.js
+++ b/src/components/MaterialUI/Inputs/Radio.test.js
@@ -119,6 +119,13 @@ describe("Radio Component", () => {
 		);
 	});
 
+	it("Fails if less than one options", () => {
+		radioProps.set(RadioProps.propNames.radios, []);
+		radioProps.set(RadioProps.propNames.allowSingleRadio, true);
+
+		expect(() => mount(<Radio radioProps={radioProps} />), "to throw", "Radio component must have at least one option");
+	});
+
 	it("Fails if two options with same value", () => {
 		radioProps.set(RadioProps.propNames.radios, [
 			{ label: "Option 1", value: "option1" },
@@ -169,6 +176,18 @@ describe("Radio Component", () => {
 		radioProps.set(RadioProps.propNames.radios, radios);
 		radioProps.set(RadioProps.propNames.row, true);
 		radioProps.set(RadioProps.propNames.disabled, true);
+
+		ExpectComponentToBeRenderedProperly(radioProps);
+	});
+
+	it("Renders Radio component properly with one option", () => {
+		radioProps.set(RadioProps.propNames.label, "aRadioLabel");
+		radioProps.set(RadioProps.propNames.defaultVal, "option1");
+		radioProps.set(RadioProps.propNames.value, "option1");
+		radioProps.set(RadioProps.propNames.radios, radios.slice(0, 1));
+		radioProps.set(RadioProps.propNames.row, true);
+		radioProps.set(RadioProps.propNames.disabled, true);
+		radioProps.set(RadioProps.propNames.allowSingleRadio, true);
 
 		ExpectComponentToBeRenderedProperly(radioProps);
 	});

--- a/src/components/MaterialUI/Inputs/RadioProps.js
+++ b/src/components/MaterialUI/Inputs/RadioProps.js
@@ -10,6 +10,7 @@ class RadioProps extends ComponentProps {
 		name: "name",
 		radios: "radios",
 		disabled: "disabled",
+		allowSingleRadio: "allowSingleRadio",
 	};
 
 	constructor() {
@@ -22,6 +23,7 @@ class RadioProps extends ComponentProps {
 		this.componentProps.set(this.constructor.propNames.name, null);
 		this.componentProps.set(this.constructor.propNames.radios, null);
 		this.componentProps.set(this.constructor.propNames.disabled, null);
+		this.componentProps.set(this.constructor.propNames.allowSingleRadio, null);
 
 		this._isRadioProps = true;
 	}

--- a/src/components/MaterialUI/Inputs/RadioProps.test.js
+++ b/src/components/MaterialUI/Inputs/RadioProps.test.js
@@ -1,7 +1,7 @@
 import RadioProps, { isRadioProps } from "./RadioProps";
 
 describe("Select Props", () => {
-	const propNames = ["update", "value", "defaultVal", "label", "row", "name", "radios", "disabled"];
+	const propNames = ["update", "value", "defaultVal", "label", "row", "name", "radios", "disabled", "allowSingleRadio"];
 
 	it("Contains necessary props keys", () => expect(RadioProps.propNames, "to have keys", propNames));
 


### PR DESCRIPTION
This is used for radio groups that are created using values from the
backend like the fulfillment method types. Some customers have only one
fulfillment method type enabled and it needs to be selected when
creating a new order.

 #46210