### PR TITLE
Correct Numeric input for FireFox, with onBlur

### DIFF
--- a/src/components/MaterialUI/Inputs/InputBase.js
+++ b/src/components/MaterialUI/Inputs/InputBase.js
@@ -99,6 +99,11 @@ const InputBase = ({ inputProps }) => {
 	const endAdornment = inputProps?.get(InputBaseProps.propNames.endAdornment);
 	const metadata = inputProps?.get(InputBaseProps.propNames.metadata);
 
+	const onClick = item => {
+		// Fixes FireFox issue, where the input number buttons do not focus on input control,
+		// causing onBlur to never fire
+		item.target.focus();
+	};
 	const classes = useStyles({ label, errorPosition });
 
 	const onChangeHandler = event => {
@@ -122,6 +127,7 @@ const InputBase = ({ inputProps }) => {
 						inputMultiline: classes.inputMultiline,
 					}}
 					onBlur={onBlur}
+					onClick={onClick}
 					type={type}
 					placeholder={placeholder}
 					value={value}

--- a/src/components/MaterialUI/Inputs/InputBase.test.js
+++ b/src/components/MaterialUI/Inputs/InputBase.test.js
@@ -113,6 +113,28 @@ describe("InputBase Component", () => {
 		expect(update, "to have calls satisfying", [{ args: [aValue, metadata] }]);
 	});
 
+	it("InputBase component handles focus on click", async () => {
+		const onFocus = jest.fn();
+		const inputProps = new InputBaseProps();
+		const aLabel = "aLabel";
+
+		const metadata = {
+			test: "value",
+		};
+
+		inputProps.set(InputBaseProps.propNames.value, "");
+		inputProps.set(InputBaseProps.propNames.update, update);
+		inputProps.set(InputBaseProps.propNames.label, aLabel);
+		inputProps.set(InputBaseProps.propNames.metadata, metadata);
+
+		const component = <InputBase inputProps={inputProps} />;
+		const mountedComponent = mount(component);
+
+		const input = mountedComponent.find("input");
+		input.simulate("click", { target: { focus: onFocus } });
+		expect(onFocus.mock.calls.length, "to equal", 1);
+	});
+
 	it("Renders InputBase when error position is 'right'", () => {
 		const inputProps = new InputBaseProps();
 		const errorValue = "error";


### PR DESCRIPTION
Correct Numeric input for FireFox, with onBlur

Story ABCD#46327