### PR TITLE
TimeLine and Select fixes

### DIFF
--- a/src/components/MaterialUI/Inputs/Select.js
+++ b/src/components/MaterialUI/Inputs/Select.js
@@ -9,6 +9,31 @@ import Icon from "./../DataDisplay/Icon";
 import IconButton from "@material-ui/core/IconButton";
 
 const useStyles = makeStyles(theme => ({
+	level0: {},
+	level1: {
+		paddingLeft: theme.spacing(theme.indent),
+	},
+	level2: {
+		paddingLeft: theme.spacing(theme.indent * 2),
+	},
+	level3: {
+		paddingLeft: theme.spacing(theme.indent * 3),
+	},
+	level4: {
+		paddingLeft: theme.spacing(theme.indent * 4),
+	},
+	level5: {
+		paddingLeft: theme.spacing(theme.indent * 5),
+	},
+	level6: {
+		paddingLeft: theme.spacing(theme.indent * 6),
+	},
+	level7: {
+		paddingLeft: theme.spacing(theme.indent * 7),
+	},
+	level8: {
+		paddingLeft: theme.spacing(theme.indent * 8),
+	},
 	container: {
 		display: "flex",
 		flexDirection: "column",
@@ -163,11 +188,14 @@ const Select = ({ options, selectProps }) => {
 		...getIconButtonMenuProps(ref.current),
 	};
 
-	const items = options?.map(option => (
-		<MenuItem key={option.value} value={option.value}>
-			<TooltippedTypography noWrap className={classes.label} children={option.label} titleValue={option.label} />
-		</MenuItem>
-	));
+	const items = options?.map(option => {
+		let clss = option?.level ? classes["level" + option.level] : "";
+		return (
+			<MenuItem key={option.value} value={option.value} className={clss}>
+				<TooltippedTypography noWrap className={classes.label} children={option.label} titleValue={option.label} />
+			</MenuItem>
+		);
+	});
 
 	const defaultSelect = (
 		<SelectMUI

--- a/src/components/MaterialUI/Inputs/Select.test.js
+++ b/src/components/MaterialUI/Inputs/Select.test.js
@@ -75,6 +75,47 @@ describe("Select Component", () => {
 		expect(component, "when mounted", "to satisfy", expected);
 	});
 
+	it("Renders Select component without indent classes", () => {
+		const options = [
+			{ value: "aValue", label: "aLabel", level: 0 },
+			{ value: "anotherValue", label: "anotherLabel", level: 1 },
+			{ value: "aThirdValue", label: "aThirdLabel", level: 2 },
+		];
+
+		const selectProps = new SelectProps();
+
+		selectProps.set(SelectProps.propNames.update, update);
+		selectProps.set(SelectProps.propNames.value, "aValue");
+
+		const component = (
+			<TestWrapper stylesProvider muiThemeProvider={{ theme }}>
+				<Select options={options} selectProps={selectProps} />
+			</TestWrapper>
+		);
+
+		const ChevronDown = props => {
+			return <Icon id="dropdown-chevron-down" {...props} />;
+		};
+
+		const expected = (
+			<TestWrapper stylesProvider muiThemeProvider={{ theme }}>
+				<SelectMUI value="aValue" disableUnderline={true} IconComponent={ChevronDown} error={false}>
+					<MenuItem key="aValue" value="aValue">
+						<TooltippedTypography children="aLabel" titleValue="aLabel" />
+					</MenuItem>
+					<MenuItem key="anotherValue" value="anotherValue" className="makeStyles-level1">
+						<TooltippedTypography noWrap children="anotherLabel" titleValue="anotherLabel" />
+					</MenuItem>
+					<MenuItem key="anotherValue" value="anotherValue" className="makeStyles-level2">
+						<TooltippedTypography noWrap children="anotherLabel" titleValue="anotherLabel" />
+					</MenuItem>
+				</SelectMUI>
+			</TestWrapper>
+		);
+
+		expect(component, "when mounted", "to satisfy", expected);
+	});
+
 	it("Renders Select component with an error message", () => {
 		const options = [
 			{ value: "aValue", label: "aLabel" },

--- a/src/components/MaterialUI/Inputs/Select.test.js
+++ b/src/components/MaterialUI/Inputs/Select.test.js
@@ -106,8 +106,8 @@ describe("Select Component", () => {
 					<MenuItem key="anotherValue" value="anotherValue" className="makeStyles-level1">
 						<TooltippedTypography noWrap children="anotherLabel" titleValue="anotherLabel" />
 					</MenuItem>
-					<MenuItem key="anotherValue" value="anotherValue" className="makeStyles-level2">
-						<TooltippedTypography noWrap children="anotherLabel" titleValue="anotherLabel" />
+					<MenuItem key="aThirdValue" value="aThirdValue" className="makeStyles-level2">
+						<TooltippedTypography noWrap children="aThirdLabel" titleValue="aThirdLabel" />
 					</MenuItem>
 				</SelectMUI>
 			</TestWrapper>

--- a/src/components/MaterialUI/Inputs/Select.test.js
+++ b/src/components/MaterialUI/Inputs/Select.test.js
@@ -75,7 +75,7 @@ describe("Select Component", () => {
 		expect(component, "when mounted", "to satisfy", expected);
 	});
 
-	it("Renders Select component without indent classes", () => {
+	it("Renders Select component with indent classes", () => {
 		const options = [
 			{ value: "aValue", label: "aLabel", level: 0 },
 			{ value: "anotherValue", label: "anotherLabel", level: 1 },

--- a/src/components/MaterialUI/muiThemes.js
+++ b/src/components/MaterialUI/muiThemes.js
@@ -1004,7 +1004,7 @@ const setThemeOverrides = theme => ({
 	MuiTimelineOppositeContent: {
 		root: {
 			...theme.root,
-			flex: 1,
+			flex: "2 0 0",
 			padding: theme.spacing(0, 2, 2),
 		},
 	},

--- a/src/components/MaterialUI/muiThemes.js
+++ b/src/components/MaterialUI/muiThemes.js
@@ -9,6 +9,7 @@ const commonTheme = {
 	shape: {
 		borderRadius: 4,
 	},
+	indent: 3,
 	typography: {
 		h1Size: 24,
 		h2Size: 18,

--- a/src/components/MaterialUI/muiThemes.js
+++ b/src/components/MaterialUI/muiThemes.js
@@ -997,6 +997,7 @@ const setThemeOverrides = theme => ({
 			...theme.root,
 			flex: 13,
 			padding: theme.spacing(0, 2, 2),
+			wordBreak: "break-word",
 		},
 	},
 	MuiTimelineOppositeContent: {


### PR DESCRIPTION
+ Add some width to the left side content of the TimeLine
+ Added word-break to allow content wrapping for TimeLine content
+ Add styles for multiple levels Select options
+ Add way to parse the level passed from the Select options
+ Add a configurable base value for the indent amount in theme