### PR TITLE
Add params to selection list

### DIFF
--- a/src/components/MaterialUI/DataDisplay/SelectionList.js
+++ b/src/components/MaterialUI/DataDisplay/SelectionList.js
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import { makeStyles } from "@material-ui/core/styles";
 import Grid from "@material-ui/core/Grid";
 import { ScrollableCustomList } from "./TransferList";
@@ -35,6 +35,8 @@ const useStyles = makeStyles(theme => ({
 	},
 }));
 
+const defaultInfoPanelXs = 7;
+
 const formatOnChange = (data, ids) => {
 	const selectedItems = data.filter(dataItem => ids.includes(dataItem.id));
 
@@ -53,47 +55,72 @@ const SelectionList = ({
 	pageSize = 20,
 	height = 50,
 	multiSelect = false,
+	defaultSelection = [],
 	infoPanel,
+	infoPanelXs,
+	divider = true,
 }) => {
 	const classes = useStyles({ height });
 	const [checked, setChecked] = useState([]);
 	const refScrollableList = React.useRef();
 
+	useEffect(() => {
+		if (checked.length === 0 && defaultSelection.length > 0) {
+			setChecked(defaultSelection);
+		}
+	}, [checked.length, defaultSelection]);
+
 	const onChangeEvent = ids => {
-		onChange(formatOnChange(listData.data, ids));
+		onChange && onChange(formatOnChange(listData.data, ids));
 	};
 
+	const showDivider = infoPanel && divider;
 	const dividerProps = new DividerProps();
-
 	dividerProps.set(DividerProps.propNames.orientation, "vertical");
 	dividerProps.set(DividerProps.propNames.light, true);
 	dividerProps.setStyle(DividerProps.ruleNames.vertical, classes.divider);
 
+	const listComponent = (
+		<Grid item xs={showDivider ? 11 : 12}>
+			<div className={classes.title}>{listData.title}</div>
+			<ScrollableCustomList
+				ref={refScrollableList}
+				onScroll={onScroll}
+				currentPage={currentPage}
+				currentTotal={currentTotal}
+				pageSize={pageSize}
+				classes={classes}
+				items={listData.data}
+				checked={checked}
+				setChecked={setChecked}
+				listItemFormatter={listItemFormatter}
+				multiSelect={multiSelect}
+				onChange={onChangeEvent}
+			/>
+		</Grid>
+	);
+
+	const dividerComponent = showDivider && (
+		<Grid item xs={1}>
+			<Divider dividerProps={dividerProps} />
+		</Grid>
+	);
+
+	const listContainer = (
+		<Grid container spacing={1}>
+			{listComponent}
+			{dividerComponent}
+		</Grid>
+	);
+
+	if (!infoPanel) return listContainer;
+
 	return (
-		<Grid container spacing={2}>
-			<Grid item xs={5}>
-				<div className={classes.title}>{listData.title}</div>
-				<ScrollableCustomList
-					ref={refScrollableList}
-					onScroll={onScroll}
-					currentPage={currentPage}
-					currentTotal={currentTotal}
-					pageSize={pageSize}
-					classes={classes}
-					items={listData.data}
-					checked={checked}
-					setChecked={setChecked}
-					listItemFormatter={listItemFormatter}
-					multiSelect={multiSelect}
-					onChange={onChangeEvent}
-				/>
+		<Grid container spacing={1}>
+			<Grid item xs={12 - (infoPanelXs ?? defaultInfoPanelXs)}>
+				{listContainer}
 			</Grid>
-			{infoPanel && (
-				<Grid item xs={1}>
-					<Divider dividerProps={dividerProps} />
-				</Grid>
-			)}
-			<Grid item xs={infoPanel ? 6 : 7}>
+			<Grid item xs={infoPanelXs ?? defaultInfoPanelXs}>
 				{infoPanel}
 			</Grid>
 		</Grid>

--- a/src/components/MaterialUI/DataDisplay/SelectionList.js
+++ b/src/components/MaterialUI/DataDisplay/SelectionList.js
@@ -55,7 +55,7 @@ const SelectionList = ({
 	pageSize = 20,
 	height = 50,
 	multiSelect = false,
-	defaultSelection = [],
+	defaultSelection,
 	infoPanel,
 	infoPanelXs,
 	divider = true,
@@ -65,10 +65,10 @@ const SelectionList = ({
 	const refScrollableList = React.useRef();
 
 	useEffect(() => {
-		if (checked.length === 0 && defaultSelection.length > 0) {
-			setChecked(defaultSelection);
+		if (defaultSelection && checked.length === 0) {
+			setChecked([defaultSelection]);
 		}
-	}, [checked.length, defaultSelection]);
+	}, [defaultSelection, checked.length]);
 
 	const onChangeEvent = ids => {
 		onChange && onChange(formatOnChange(listData.data, ids));

--- a/src/components/MaterialUI/DataDisplay/SelectionList.test.js
+++ b/src/components/MaterialUI/DataDisplay/SelectionList.test.js
@@ -36,7 +36,6 @@ describe("SelectionList", () => {
 						<div>{listTitle}</div>
 						<ScrollableCustomList checked={[]} items={list} classes={{}} />
 					</Grid>
-					<Grid />
 				</Grid>
 			</TestWrapper>
 		);
@@ -55,20 +54,52 @@ describe("SelectionList", () => {
 		);
 
 		const expected = (
-			<TestWrapper intlProvider={{ messages }}>
+			<Grid>
 				<Grid>
 					<Grid>
-						<div>{listTitle}</div>
-						<ScrollableCustomList checked={[]} items={list} classes={{}} />
-					</Grid>
-					<Grid>
-						<hr />
-					</Grid>
-					<Grid>
-						<div>Test</div>
+						<Grid>
+							<div>{listTitle}</div>
+							<ScrollableCustomList checked={[]} items={list} classes={{}} />
+						</Grid>
+						<Grid>
+							<hr />
+						</Grid>
 					</Grid>
 				</Grid>
+				<Grid>
+					<div>Test</div>
+				</Grid>
+			</Grid>
+		);
+
+		expect(component, "when mounted", "to satisfy", expected);
+	});
+
+	it("Renders SelectionList correctly if infoPanel is supplied without divider", () => {
+		const component = (
+			<TestWrapper intlProvider={{ messages }}>
+				<SelectionList
+					listData={{ title: listTitle, data: [{ id: "id1", disabled: true, title: "item1" }] }}
+					infoPanel={<div>Test</div>}
+					divider={false}
+				/>
 			</TestWrapper>
+		);
+
+		const expected = (
+			<Grid>
+				<Grid>
+					<Grid>
+						<Grid>
+							<div>{listTitle}</div>
+							<ScrollableCustomList checked={[]} items={list} classes={{}} />
+						</Grid>
+					</Grid>
+				</Grid>
+				<Grid>
+					<div>Test</div>
+				</Grid>
+			</Grid>
 		);
 
 		expect(component, "when mounted", "to satisfy", expected);
@@ -86,7 +117,28 @@ describe("SelectionList", () => {
 		let item = mountedComponent.find(ListItem).at(0);
 		item.invoke("onClick")();
 
-		expect(onChange, "to have calls satisfying", [{ args: [{ selectedItems: [list[0]] }] }]);
+		expect(onChange.args[1][0], "to equal", { selectedItems: [list[0]] });
+	});
+
+	it("Calls onChange with defaultSelection", () => {
+		const data = [
+			{ id: "id1", title: "item1" },
+			{ id: "id2", title: "item2" },
+		];
+
+		const component = (
+			<TestWrapper intlProvider={{ messages }}>
+				<SelectionList
+					listData={{ title: listTitle, data: data }}
+					defaultSelection={[data[1].id]}
+					onChange={onChange}
+				/>
+			</TestWrapper>
+		);
+
+		mount(component);
+
+		expect(onChange.args[1][0], "to equal", { selectedItems: [data[1]] });
 	});
 
 	it("handle scrolling event", () => {

--- a/src/components/MaterialUI/DataDisplay/SelectionList.test.js
+++ b/src/components/MaterialUI/DataDisplay/SelectionList.test.js
@@ -128,11 +128,7 @@ describe("SelectionList", () => {
 
 		const component = (
 			<TestWrapper intlProvider={{ messages }}>
-				<SelectionList
-					listData={{ title: listTitle, data: data }}
-					defaultSelection={[data[1].id]}
-					onChange={onChange}
-				/>
+				<SelectionList listData={{ title: listTitle, data: data }} defaultSelection={data[1].id} onChange={onChange} />
 			</TestWrapper>
 		);
 

--- a/src/components/MaterialUI/DataDisplay/TransferList.js
+++ b/src/components/MaterialUI/DataDisplay/TransferList.js
@@ -1,4 +1,4 @@
-import React, { useState, useCallback } from "react";
+import React, { useState, useEffect, useCallback } from "react";
 import { FormattedMessage } from "react-intl";
 import { makeStyles } from "@material-ui/core/styles";
 import Grid from "@material-ui/core/Grid";
@@ -153,13 +153,12 @@ export const CustomList = ({ items, checked, setChecked, listItemFormatter, mult
 					}
 				}
 
-				if (onChange) {
-					onChange(newChecked);
-				}
 				return newChecked;
 			}),
-		[setChecked, multiSelect, onChange],
+		[setChecked, multiSelect],
 	);
+
+	useEffect(() => onChange && onChange(checked), [checked, onChange]);
 
 	return (
 		<List component="div" role="list">


### PR DESCRIPTION
In TransferList, setChecked and onChange sometimes both cause re-renders
Sometimes, the onChange setState is called before the setChecked rendering finishes and react throws a warning "invalid setState during component rendering"

Calling onChange with useEffect fixes the problem