### PR TITLE
Updates for Badge, Popper and SearchControl

### DIFF
--- a/src/components/MaterialUI/DataDisplay/Badge.js
+++ b/src/components/MaterialUI/DataDisplay/Badge.js
@@ -13,11 +13,7 @@ const useStyles = makeStyles(theme => ({
 
 const Badge = ({ children, badge, ...props }) => {
 	const classes = useStyles();
-	const classProp = props.classProp;
-
-	if (!classProp?.badge) {
-		classProp.badge = classes.badge;
-	}
+	const classProp = !!props.classProp?.badge ? props.classProp : classes;
 
 	return (
 		<BadgeMui overlap="circle" color="primary" max={999} badgeContent={badge} classes={classProp}>

--- a/src/components/MaterialUI/DataDisplay/Badge.js
+++ b/src/components/MaterialUI/DataDisplay/Badge.js
@@ -11,11 +11,16 @@ const useStyles = makeStyles(theme => ({
 	},
 }));
 
-const Badge = ({ children, badge }) => {
+const Badge = ({ children, badge, ...props }) => {
 	const classes = useStyles();
+	const classProp = props.classProp;
+
+	if (!classProp?.badge) {
+		classProp.badge = classes.badge;
+	}
 
 	return (
-		<BadgeMui overlap="circle" color="primary" max={999} badgeContent={badge} classes={{ badge: classes.badge }}>
+		<BadgeMui overlap="circle" color="primary" max={999} badgeContent={badge} classes={classProp}>
 			{children}
 		</BadgeMui>
 	);

--- a/src/components/MaterialUI/DataDisplay/Badge.test.js
+++ b/src/components/MaterialUI/DataDisplay/Badge.test.js
@@ -2,6 +2,7 @@ import React from "react";
 import { mount } from "enzyme";
 import Badge from "./Badge";
 import BadgeMui from "@material-ui/core/Badge";
+import { makeStyles } from "@material-ui/core/styles";
 
 describe("Badge", () => {
 	it("Renders Badge when children was passed", () => {
@@ -17,7 +18,7 @@ describe("Badge", () => {
 		expect(mountedComponent.containsMatchingElement(expected), "to be true");
 	});
 
-	it("Renders Badge when was not passed", () => {
+	it("Renders Badge when children was not passed", () => {
 		const badge = 10;
 
 		const component = <Badge badge={badge} />;
@@ -25,6 +26,35 @@ describe("Badge", () => {
 		const mountedComponent = mount(component);
 
 		const expected = <BadgeMui badgeContent={badge} />;
+
+		expect(mountedComponent.containsMatchingElement(expected), "to be true");
+	});
+
+	it("Renders Badge when classprop is not null", () => {
+		const useStyles = makeStyles(theme => ({
+			badge: {
+				color: theme.palette.background.default,
+				height: theme.spacing(2.8),
+				borderRadius: theme.spacing(2.8),
+				padding: theme.spacing(1),
+			},
+		}));
+
+		const badge = 10;
+		const children = <p>Hello</p>;
+
+		const Component = () => {
+			const customClass = useStyles();
+			return <Badge badge={badge} children={children} classProp={customClass} />;
+		};
+
+		const mountedComponent = mount(<Component />);
+
+		const mountedProps = mountedComponent.prop("classProp");
+
+		expect(mountedProps, "not to be null");
+
+		const expected = <BadgeMui badgeContent={badge}>{children}</BadgeMui>;
 
 		expect(mountedComponent.containsMatchingElement(expected), "to be true");
 	});

--- a/src/components/MaterialUI/Inputs/PredefinedElements/SearchControl.js
+++ b/src/components/MaterialUI/Inputs/PredefinedElements/SearchControl.js
@@ -90,6 +90,20 @@ export const useStyles = makeStyles(theme => ({
 		display: "inherit",
 		marginLeft: theme.spacing(-0.1),
 		marginRight: theme.spacing(-0.1),
+		borderTopLeftRadius: theme.shape.borderRadius,
+		borderBottomLeftRadius: theme.shape.borderRadius,
+		"& $controlInput": {
+			borderTopLeftRadius: theme.shape.borderRadius,
+			borderBottomLeftRadius: theme.shape.borderRadius,
+		},
+		".MuiInputBase-root ~ &": {
+			borderTopLeftRadius: 0,
+			borderBottomLeftRadius: 0,
+			"& $controlInput": {
+				borderTopLeftRadius: 0,
+				borderBottomLeftRadius: 0,
+			},
+		},
 	},
 	selectRoot: {
 		zIndex: 10,
@@ -113,8 +127,10 @@ export const useStyles = makeStyles(theme => ({
 }));
 
 const SearchControl = ({ placeholder, defaultValue = "", searchOptions, onSearch = () => {} }) => {
+	searchOptions = !searchOptions?.length ? null : searchOptions;
+	const baseValue = !!searchOptions ? searchOptions[0].value : null;
 	const [inputFocused, setInputFocused] = useState(false);
-	const [searchOption, setSearchOption] = useState(searchOptions[0].value);
+	const [searchOption, setSearchOption] = useState(baseValue);
 
 	const classes = useStyles({ focused: inputFocused });
 
@@ -150,6 +166,11 @@ const SearchControl = ({ placeholder, defaultValue = "", searchOptions, onSearch
 		setInputFocused(focused);
 		event.preventDefault();
 		event.stopPropagation();
+	};
+
+	const SelectSection = () => {
+		if (searchOptions === null) return null;
+		else return <Select className={classes.selectInput} options={searchOptions} selectProps={selectProps} />;
 	};
 
 	const inputSection = (
@@ -193,7 +214,7 @@ const SearchControl = ({ placeholder, defaultValue = "", searchOptions, onSearch
 
 	return (
 		<div className={classes.container}>
-			<Select className={classes.selectInput} options={searchOptions} selectProps={selectProps} />
+			<SelectSection />
 			{inputSection}
 			{searchSection}
 		</div>

--- a/src/components/MaterialUI/Inputs/PredefinedElements/SearchControl.test.js
+++ b/src/components/MaterialUI/Inputs/PredefinedElements/SearchControl.test.js
@@ -107,6 +107,88 @@ describe("SearchControl Component", () => {
 		expect(component, "when mounted", "to satisfy", expected);
 	});
 
+	it("Renders Search Control component without errors when searchOptions are empty", () => {
+		const options = [];
+
+		const component = (
+			<TestWrapper stylesProvider muiThemeProvider={{ theme }}>
+				<SearchControl placeholder="placeHolderTest" defaultValue="default" searchOptions={options} />
+			</TestWrapper>
+		);
+
+		const selectProps = new SelectProps();
+		selectProps.set(SelectProps.propNames.value, "aValue");
+
+		const expected = (
+			<TestWrapper stylesProvider muiThemeProvider={{ theme }}>
+				<div>
+					<div>
+						<form>
+							<Input
+								placeholder="placeHolderTest"
+								defaultValue="default"
+								disableUnderline={true}
+								endAdornment={
+									<InputAdornment position="start">
+										<IconButton tabIndex="-1" type="reset">
+											<Icon id="close2" />
+										</IconButton>
+									</InputAdornment>
+								}
+							/>
+						</form>
+					</div>
+					<IconButton>
+						<Icon id="search" />
+					</IconButton>
+				</div>
+			</TestWrapper>
+		);
+
+		expect(component, "when mounted", "to satisfy", expected);
+	});
+
+	it("Renders Search Control component without errors when searchOptions are null", () => {
+		const options = null;
+
+		const component = (
+			<TestWrapper stylesProvider muiThemeProvider={{ theme }}>
+				<SearchControl placeholder="placeHolderTest" defaultValue="default" searchOptions={options} />
+			</TestWrapper>
+		);
+
+		const selectProps = new SelectProps();
+		selectProps.set(SelectProps.propNames.value, "aValue");
+
+		const expected = (
+			<TestWrapper stylesProvider muiThemeProvider={{ theme }}>
+				<div>
+					<div>
+						<form>
+							<Input
+								placeholder="placeHolderTest"
+								defaultValue="default"
+								disableUnderline={true}
+								endAdornment={
+									<InputAdornment position="start">
+										<IconButton tabIndex="-1" type="reset">
+											<Icon id="close2" />
+										</IconButton>
+									</InputAdornment>
+								}
+							/>
+						</form>
+					</div>
+					<IconButton>
+						<Icon id="search" />
+					</IconButton>
+				</div>
+			</TestWrapper>
+		);
+
+		expect(component, "when mounted", "to satisfy", expected);
+	});
+
 	it("Search Control should trigger the event when hitting Enter even without prop", () => {
 		const options = [
 			{ value: "aValue", label: "aLabel" },

--- a/src/components/MaterialUI/hocs/withDeferredPopper.js
+++ b/src/components/MaterialUI/hocs/withDeferredPopper.js
@@ -77,7 +77,7 @@ const withDeferredPopper =
 		const defaultComponent = <Comp onClick={event => togglePopper(event)} {...props} />;
 
 		const togglePopper = function (event) {
-			const linkParent = event._dispatchInstances.filter(item => item.elementType === "a");
+			const linkParent = event?._dispatchInstances?.filter(item => item.elementType === "a");
 			if (linkParent) {
 				event.preventDefault();
 			}
@@ -102,21 +102,15 @@ const withDeferredPopper =
 
 		const classProp = props.classprop ? props.classprop : classes;
 
-		if (!classProp.popperContainer) {
-			classProp.popperContainer = classes.popperContainer;
-		}
+		classProp.popperContainer = classProp.popperContainer ?? classes.popperContainer;
 
-		if (!classProp.popper) {
-			classProp.popper = classes.popper;
-		}
+		classProp.popper = classProp.popper ?? classes.popper;
 
-		if (!classProp.arrow) {
-			classProp.arrow = classes.arrow;
-		}
+		classProp.arrow = classProp.arrow ?? classes.arrow;
 
 		return (
 			<ClickAwayListener onClickAway={() => clickAwayHandler()}>
-				<div className={classProp.popperContainer}>
+				<div className={classProp.popperContainer} data-qa="popperContainer">
 					{defaultComponent}
 					<Popper
 						className={classProp.popper}

--- a/src/components/MaterialUI/hocs/withDeferredPopper.js
+++ b/src/components/MaterialUI/hocs/withDeferredPopper.js
@@ -66,6 +66,7 @@ const withDeferredPopper =
 		const [popperState, setPopperState] = useState({
 			isDisplayed: false,
 			anchorElement: null,
+			arrowElement: null,
 		});
 
 		if (popperValue == null) return <Comp {...props} />;
@@ -113,6 +114,7 @@ const withDeferredPopper =
 				<div className={classProp.popperContainer} data-qa="popperContainer">
 					{defaultComponent}
 					<Popper
+						data-qa="poperComponent"
 						className={classProp.popper}
 						modifiers={{
 							offset: {
@@ -120,7 +122,7 @@ const withDeferredPopper =
 							},
 							arrow: {
 								enabled: true,
-								element: popperState.anchorElement,
+								element: classProp.arrow,
 							},
 						}}
 						open={popperState.isDisplayed}

--- a/src/components/MaterialUI/hocs/withDeferredPopper.js
+++ b/src/components/MaterialUI/hocs/withDeferredPopper.js
@@ -63,12 +63,6 @@ const withDeferredPopper =
 	({ popperValue, ...props }) => {
 		const classes = useStyles();
 
-		const classProp = props?.classProp ? props.classProp : classes;
-
-		if (classProp?.popperContainer) classProp.popwerContainer = classes.popperContainer;
-		if (classProp?.poper) classProp.poper = classes.poper;
-		if (classProp?.arrow) classProp.arrow = classes.arrow;
-
 		const [popperState, setPopperState] = useState({
 			isDisplayed: false,
 			anchorElement: null,
@@ -83,21 +77,42 @@ const withDeferredPopper =
 		const defaultComponent = <Comp onClick={event => togglePopper(event)} {...props} />;
 
 		const togglePopper = function (event) {
+			const linkParent = event._dispatchInstances.filter(item => item.elementType === "a");
+			if (linkParent) {
+				event.preventDefault();
+			}
 			const isDisplayed = !popperState.isDisplayed;
 			const anchorElement = event.currentTarget;
 			setPopperState({
 				isDisplayed: isDisplayed,
 				anchorElement: anchorElement,
 			});
+			event.bubbles = false;
 			event.stopPropagation();
 		};
 
 		const clickAwayHandler = function () {
-			setPopperState({
-				isDisplayed: false,
-				anchorElement: null,
-			});
+			if (popperState.anchorElement) {
+				setPopperState({
+					isDisplayed: false,
+					anchorElement: null,
+				});
+			}
 		};
+
+		const classProp = props.classprop ? props.classprop : classes;
+
+		if (!classProp.popperContainer) {
+			classProp.popperContainer = classes.popperContainer;
+		}
+
+		if (!classProp.popper) {
+			classProp.popper = classes.popper;
+		}
+
+		if (!classProp.arrow) {
+			classProp.arrow = classes.arrow;
+		}
 
 		return (
 			<ClickAwayListener onClickAway={() => clickAwayHandler()}>

--- a/src/components/MaterialUI/hocs/withDeferredPopper.js
+++ b/src/components/MaterialUI/hocs/withDeferredPopper.js
@@ -58,63 +58,71 @@ export const Arrow = ({ arrowClass }) => {
 	return <div className={arrowClass} />;
 };
 
-const withDeferredPopper = Comp => ({ popperValue, ...props }) => {
-	const classes = useStyles();
+const withDeferredPopper =
+	Comp =>
+	({ popperValue, ...props }) => {
+		const classes = useStyles();
 
-	const [popperState, setPopperState] = useState({
-		isDisplayed: false,
-		anchorElement: null,
-	});
+		const classProp = props?.classProp ? props.classProp : classes;
 
-	if (popperValue == null) return <Comp {...props} />;
+		if (classProp?.popperContainer) classProp.popwerContainer = classes.popperContainer;
+		if (classProp?.poper) classProp.poper = classes.poper;
+		if (classProp?.arrow) classProp.arrow = classes.arrow;
 
-	if (isString(popperValue) && isStringNullOrWhitespace(popperValue)) return <Comp {...props} />;
-
-	if (isObject(popperValue) && isReactComponent(popperValue) === false) return <Comp {...props} />;
-
-	const defaultComponent = <Comp onClick={event => togglePopper(event)} {...props} />;
-
-	const togglePopper = function (event) {
-		const isDisplayed = !popperState.isDisplayed;
-		const anchorElement = event.currentTarget;
-		setPopperState({
-			isDisplayed: isDisplayed,
-			anchorElement: anchorElement,
-		});
-		event.stopPropagation();
-	};
-
-	const clickAwayHandler = function () {
-		setPopperState({
+		const [popperState, setPopperState] = useState({
 			isDisplayed: false,
 			anchorElement: null,
 		});
-	};
 
-	return (
-		<ClickAwayListener onClickAway={() => clickAwayHandler()}>
-			<div className={classes.popperContainer}>
-				{defaultComponent}
-				<Popper
-					className={classes.popper}
-					modifiers={{
-						offset: {
-							offset: "0, 10",
-						},
-						arrow: {
-							enabled: true,
-							element: popperState.anchorElement,
-						},
-					}}
-					open={popperState.isDisplayed}
-					anchorEl={popperState.anchorElement}
-				>
-					<Arrow arrowClass={classes.arrow} />
-					{popperValue}
-				</Popper>
-			</div>
-		</ClickAwayListener>
-	);
-};
+		if (popperValue == null) return <Comp {...props} />;
+
+		if (isString(popperValue) && isStringNullOrWhitespace(popperValue)) return <Comp {...props} />;
+
+		if (isObject(popperValue) && isReactComponent(popperValue) === false) return <Comp {...props} />;
+
+		const defaultComponent = <Comp onClick={event => togglePopper(event)} {...props} />;
+
+		const togglePopper = function (event) {
+			const isDisplayed = !popperState.isDisplayed;
+			const anchorElement = event.currentTarget;
+			setPopperState({
+				isDisplayed: isDisplayed,
+				anchorElement: anchorElement,
+			});
+			event.stopPropagation();
+		};
+
+		const clickAwayHandler = function () {
+			setPopperState({
+				isDisplayed: false,
+				anchorElement: null,
+			});
+		};
+
+		return (
+			<ClickAwayListener onClickAway={() => clickAwayHandler()}>
+				<div className={classProp.popperContainer}>
+					{defaultComponent}
+					<Popper
+						className={classProp.popper}
+						modifiers={{
+							offset: {
+								offset: "0, 10",
+							},
+							arrow: {
+								enabled: true,
+								element: popperState.anchorElement,
+							},
+						}}
+						open={popperState.isDisplayed}
+						anchorEl={popperState.anchorElement}
+					>
+						<Arrow arrowClass={classProp.arrow} />
+						{popperValue}
+					</Popper>
+				</div>
+			</ClickAwayListener>
+		);
+	};
 
 export default withDeferredPopper;

--- a/src/components/MaterialUI/hocs/withDeferredPopper.test.js
+++ b/src/components/MaterialUI/hocs/withDeferredPopper.test.js
@@ -93,11 +93,10 @@ describe("withDeferredPopper", () => {
 			return <PopperedCompponent popperValue={popperValue} classprop={myProps} />;
 		};
 
-		let mountHolder = shallow(<Holder />);
-		let mountedPopperedComponent = mount(<PopperedCompponent popperValue={popperValue} classprop={myProps} />);
+		let mountHolder = mount(<Holder />);
 
 		ignoreConsoleError(() => {
-			const mountedProps = mountedPopperedComponent.prop("classprop");
+			const mountedProps = mountHolder.find(PopperedCompponent).prop("classprop");
 
 			expect(mountedProps, "not to be null");
 

--- a/src/components/MaterialUI/hocs/withDeferredPopper.test.js
+++ b/src/components/MaterialUI/hocs/withDeferredPopper.test.js
@@ -139,8 +139,6 @@ describe("withDeferredPopper", () => {
 			const expected = "makeStyles-popper-1";
 
 			expect(mountedProps.popper, "to equal", expected);
-
-			expect(mountHolder.containsMatchingElement(<PopperedCompponent />), "to be true");
 		});
 	});
 
@@ -176,8 +174,6 @@ describe("withDeferredPopper", () => {
 			const expected = "makeStyles-arrow-2";
 
 			expect(mountedProps.arrow, "to equal", expected);
-
-			expect(mountHolder.containsMatchingElement(<PopperedCompponent />), "to be true");
 		});
 	});
 
@@ -215,8 +211,6 @@ describe("withDeferredPopper", () => {
 			const expected = "makeStyles-popperContainer-3";
 
 			expect(mountedProps.popperContainer, "to equal", expected);
-
-			expect(mountHolder.containsMatchingElement(<PopperedCompponent />), "to be true");
 		});
 	});
 

--- a/src/components/MaterialUI/hocs/withDeferredPopper.test.js
+++ b/src/components/MaterialUI/hocs/withDeferredPopper.test.js
@@ -4,6 +4,9 @@ import { shallow, mount } from "enzyme";
 import Popper from "@material-ui/core/Popper";
 import ClickAwayListener from "@material-ui/core/ClickAwayListener";
 import { ignoreConsoleError } from "./../../../utils/testUtils";
+import sinon from "sinon";
+import { makeStyles } from "@material-ui/core/styles";
+import Paper from "../Surfaces/Paper";
 
 describe("withDeferredPopper", () => {
 	const ComponentToBePoppered = () => {
@@ -49,15 +52,208 @@ describe("withDeferredPopper", () => {
 
 		let mountedPopperedComponent = shallow(<PopperedCompponent />);
 
-		expect(mountedPopperedComponent.contains(<Wrapper />), "to be true");
+		expect(mountedPopperedComponent.containsMatchingElement(<Wrapper />), "to be true");
 
 		mountedPopperedComponent = shallow(<PopperedCompponent popperValue={emptyString} />);
 
-		expect(mountedPopperedComponent.contains(<Wrapper />), "to be true");
+		expect(mountedPopperedComponent.containsMatchingElement(<Wrapper />), "to be true");
 
 		mountedPopperedComponent = shallow(<PopperedCompponent popperValue={notReactComponent} />);
 
-		expect(mountedPopperedComponent.contains(<Wrapper />), "to be true");
+		expect(mountedPopperedComponent.containsMatchingElement(<Wrapper />), "to be true");
+	});
+
+	it("Renders component correctly with classprop not null", () => {
+		const useStyles = makeStyles(theme => ({
+			popper: {
+				zIndex: 9999,
+			},
+			arrow: {
+				position: "absolute",
+				border: "1px solid",
+				backgroundColor: theme.palette.background.paper,
+			},
+			popperContainer: {
+				cursor: "pointer",
+			},
+		}));
+
+		const Wrapper = props => {
+			const customClass = useStyles();
+			return <ComponentToBePoppered {...props} classprop={customClass} />;
+		};
+
+		const PopperedCompponent = withDeferredPopper(Wrapper);
+		const popperValue = <Paper content="hello" />;
+
+		let myProps = {};
+
+		const Holder = () => {
+			myProps = useStyles();
+			return <PopperedCompponent popperValue={popperValue} classprop={myProps} />;
+		};
+
+		let mountHolder = shallow(<Holder />);
+		let mountedPopperedComponent = mount(<PopperedCompponent popperValue={popperValue} classprop={myProps} />);
+
+		ignoreConsoleError(() => {
+			const mountedProps = mountedPopperedComponent.prop("classprop");
+
+			expect(mountedProps, "not to be null");
+
+			expect(mountHolder.containsMatchingElement(<PopperedCompponent />), "to be true");
+		});
+	});
+
+	it("Renders component correctly with classProp.popper not defined", () => {
+		const useStyles = makeStyles(theme => ({
+			arrow: {
+				position: "absolute",
+				border: "1px solid",
+				backgroundColor: theme.palette.background.paper,
+			},
+			popperContainer: {
+				cursor: "pointer",
+			},
+		}));
+
+		const Wrapper = props => {
+			const customClass = useStyles();
+			return <ComponentToBePoppered {...props} classprop={customClass} />;
+		};
+
+		const PopperedCompponent = withDeferredPopper(Wrapper);
+		const popperValue = <Paper content="hello" />;
+
+		let myProps = {};
+
+		const Holder = () => {
+			myProps = useStyles();
+			return <PopperedCompponent popperValue={popperValue} classprop={myProps} />;
+		};
+
+		let mountHolder = mount(<Holder />);
+
+		ignoreConsoleError(() => {
+			const mountedProps = mountHolder.find(PopperedCompponent).prop("classprop");
+
+			const expected = "makeStyles-popper-1";
+
+			expect(mountedProps.popper, "to equal", expected);
+
+			expect(mountHolder.containsMatchingElement(<PopperedCompponent />), "to be true");
+		});
+	});
+
+	it("Renders component correctly with classProp.arrow not defined", () => {
+		const useStyles = makeStyles(theme => ({
+			popper: {
+				zIndex: 9999,
+			},
+			popperContainer: {
+				cursor: "pointer",
+			},
+		}));
+
+		const Wrapper = props => {
+			const customClass = useStyles();
+			return <ComponentToBePoppered {...props} classprop={customClass} />;
+		};
+
+		const PopperedCompponent = withDeferredPopper(Wrapper);
+		const popperValue = <Paper content="hello" />;
+
+		let myProps = {};
+
+		const Holder = () => {
+			myProps = useStyles();
+			return <PopperedCompponent popperValue={popperValue} classprop={myProps} />;
+		};
+
+		let mountHolder = mount(<Holder />);
+
+		ignoreConsoleError(() => {
+			const mountedProps = mountHolder.find(PopperedCompponent).prop("classprop");
+			const expected = "makeStyles-arrow-2";
+
+			expect(mountedProps.arrow, "to equal", expected);
+
+			expect(mountHolder.containsMatchingElement(<PopperedCompponent />), "to be true");
+		});
+	});
+
+	it("Renders component correctly with classProp.popperContainer not defined", () => {
+		const useStyles = makeStyles(theme => ({
+			popper: {
+				zIndex: 9999,
+			},
+			arrow: {
+				position: "absolute",
+				border: "1px solid",
+				backgroundColor: theme.palette.background.paper,
+			},
+		}));
+
+		const Wrapper = props => {
+			const customClass = useStyles();
+			return <ComponentToBePoppered {...props} classprop={customClass} />;
+		};
+
+		const PopperedCompponent = withDeferredPopper(Wrapper);
+		const popperValue = <Paper content="hello" />;
+
+		let myProps = {};
+
+		const Holder = () => {
+			myProps = useStyles();
+			return <PopperedCompponent popperValue={popperValue} classprop={myProps} />;
+		};
+
+		let mountHolder = mount(<Holder />);
+
+		ignoreConsoleError(() => {
+			const mountedProps = mountHolder.find(PopperedCompponent).prop("classprop");
+			const expected = "makeStyles-popperContainer-3";
+
+			expect(mountedProps.popperContainer, "to equal", expected);
+
+			expect(mountHolder.containsMatchingElement(<PopperedCompponent />), "to be true");
+		});
+	});
+
+	it("Prevents default click behaviour if parent is a link <a></a>", () => {
+		const parentCallback = sinon.spy();
+
+		const Wrapper = props => <ComponentToBePoppered {...props} />;
+
+		const PopperedCompponent = withDeferredPopper(Wrapper);
+
+		const popperValue = "test";
+
+		const mountedPopperedComponent = mount(
+			<a href="#hash" onClick={parentCallback}>
+				<PopperedCompponent popperValue={popperValue} />
+			</a>,
+		);
+
+		const wrapper = mountedPopperedComponent.find(Wrapper);
+
+		ignoreConsoleError(() => {
+			const event = {
+				currentTarget: wrapper,
+				stopPropagation: jest.fn(),
+				preventDefault: jest.fn(),
+				_dispatchInstances: [{ elementType: "a" }, { elementType: "div" }, { elementType: "span" }],
+			};
+
+			wrapper.invoke("onClick")(event);
+
+			let popper = mountedPopperedComponent.find(Popper);
+
+			expect(popper.prop("open"), "to be true");
+
+			expect(parentCallback, "was not called");
+		});
 	});
 
 	it("Closes popper when clickAway event occurs", () => {
@@ -88,6 +284,37 @@ describe("withDeferredPopper", () => {
 			popper = mountedPopperedComponent.find(Popper);
 
 			expect(popper.prop("open"), "to be false");
+		});
+	});
+
+	it("Does not close popper when clickAway event occurs with null event currentTarget", () => {
+		const Wrapper = props => <ComponentToBePoppered {...props} />;
+
+		const PopperedCompponent = withDeferredPopper(Wrapper);
+
+		const popperValue = "test";
+
+		const mountedPopperedComponent = mount(<PopperedCompponent popperValue={popperValue} />);
+
+		const wrapper = mountedPopperedComponent.find(Wrapper);
+
+		ignoreConsoleError(() => {
+			const event = {
+				currentTarget: null,
+				stopPropagation: jest.fn(),
+			};
+
+			wrapper.invoke("onClick")(event);
+
+			let popper = mountedPopperedComponent.find(Popper);
+
+			expect(popper.prop("open"), "to be true");
+
+			mountedPopperedComponent.find(ClickAwayListener).invoke("onClickAway")();
+
+			popper = mountedPopperedComponent.find(Popper);
+
+			expect(popper.prop("open"), "to be true");
 		});
 	});
 

--- a/src/components/Routing/SegmentPage.js
+++ b/src/components/Routing/SegmentPage.js
@@ -118,15 +118,16 @@ export const SegmentItem = ({ isModified, isError, isActive, segpath, config, ba
 		);
 
 	const finalLabel = (
-		<Grid container justify="space-between">
+		<Grid container alignItems="center">
 			<Grid
 				item
+				xs={8}
 				className={classNames(sectionLabelClassName, config.labelComponent != null ? classes.labelContainer : null)}
 			>
 				{basicLabel}
 				{isModified ? asterix : null}
 			</Grid>
-			<Grid item className={classes.labelComponent}>
+			<Grid item xs={4} container className={classes.labelComponent}>
 				{config.labelComponent}
 			</Grid>
 		</Grid>

--- a/src/components/Routing/SegmentPage.test.js
+++ b/src/components/Routing/SegmentPage.test.js
@@ -126,13 +126,13 @@ describe("SegmentPage", () => {
 				<Wrapper>
 					<List>
 						<Item to="/foo/meep/entityIdValue/one">
-							<Grid container justify="space-between">
+							<Grid container alignItems="center">
 								<Grid item>Text</Grid>
 								<Grid item></Grid>
 							</Grid>
 						</Item>
 						<Item to="/foo/meep/entityIdValue/two" active>
-							<Grid container justify="space-between">
+							<Grid container alignItems="center">
 								<Grid item>
 									Translated
 									<span>*</span>
@@ -141,7 +141,7 @@ describe("SegmentPage", () => {
 							</Grid>
 						</Item>
 						<Item to="/foo/meep/entityIdValue/three">
-							<Grid container justify="space-between">
+							<Grid container alignItems="center">
 								<Grid item>
 									<TooltippedTypography children="ComponentLabel" titleValue="ComponentLabel" noWrap />
 								</Grid>
@@ -151,13 +151,13 @@ describe("SegmentPage", () => {
 							</Grid>
 						</Item>
 						<Item>
-							<Grid container justify="space-between">
+							<Grid container alignItems="center">
 								<Grid item>DisabledSection</Grid>
 								<Grid item></Grid>
 							</Grid>
 						</Item>
 						<Item>
-							<Grid container justify="space-between">
+							<Grid container alignItems="center">
 								<Grid item>DisabledSectionBySelector</Grid>
 								<Grid item></Grid>
 							</Grid>
@@ -196,13 +196,13 @@ describe("SegmentPage", () => {
 					<Wrapper>
 						<List>
 							<Item to="/foo/meep/entityIdValue/one">
-								<Grid container justify="space-between">
+								<Grid container alignItems="center">
 									<Grid item>Text</Grid>
 									<Grid item></Grid>
 								</Grid>
 							</Item>
 							<Item to="/foo/meep/entityIdValue/two" active>
-								<Grid container justify="space-between">
+								<Grid container alignItems="center">
 									<Grid item>
 										Translated
 										<span>*</span>
@@ -211,7 +211,7 @@ describe("SegmentPage", () => {
 								</Grid>
 							</Item>
 							<Item to="/foo/meep/entityIdValue/three">
-								<Grid container justify="space-between">
+								<Grid container alignItems="center">
 									<Grid item>
 										<TooltippedTypography children="ComponentLabel" titleValue="ComponentLabel" noWrap />
 									</Grid>
@@ -221,13 +221,13 @@ describe("SegmentPage", () => {
 								</Grid>
 							</Item>
 							<Item>
-								<Grid container justify="space-between">
+								<Grid container alignItems="center">
 									<Grid item>DisabledSection</Grid>
 									<Grid item></Grid>
 								</Grid>
 							</Item>
 							<Item>
-								<Grid container justify="space-between">
+								<Grid container alignItems="center">
 									<Grid item>DisabledSectionBySelector</Grid>
 									<Grid item></Grid>
 								</Grid>
@@ -318,13 +318,13 @@ describe("SegmentPage", () => {
 				<MemoryRouter>
 					<List>
 						<Item to="/foo/meep/entityIdValue/one">
-							<Grid container justify="space-between">
+							<Grid container alignItems="center">
 								<Grid item>Text</Grid>
 								<Grid item></Grid>
 							</Grid>
 						</Item>
 						<Item to="/foo/meep/entityIdValue/two">
-							<Grid container justify="space-between">
+							<Grid container alignItems="center">
 								<Grid item>
 									Translated
 									<span>*</span>
@@ -333,7 +333,7 @@ describe("SegmentPage", () => {
 							</Grid>
 						</Item>
 						<Item to="/foo/meep/entityIdValue/three">
-							<Grid container justify="space-between">
+							<Grid container alignItems="center">
 								<Grid item>
 									<TooltippedTypography children="ComponentLabel" titleValue="ComponentLabel" noWrap />
 								</Grid>
@@ -343,13 +343,13 @@ describe("SegmentPage", () => {
 							</Grid>
 						</Item>
 						<Item>
-							<Grid container justify="space-between">
+							<Grid container alignItems="center">
 								<Grid item>DisabledSection</Grid>
 								<Grid item></Grid>
 							</Grid>
 						</Item>
 						<Item>
-							<Grid container justify="space-between">
+							<Grid container alignItems="center">
 								<Grid item>DisabledSectionBySelector</Grid>
 								<Grid item></Grid>
 							</Grid>
@@ -391,19 +391,19 @@ describe("SegmentPage", () => {
 				<MemoryRouter>
 					<List>
 						<Item to="/foo/meep/entityIdValue/one">
-							<Grid container justify="space-between">
+							<Grid container alignItems="center">
 								<Grid item>Text</Grid>
 								<Grid item></Grid>
 							</Grid>
 						</Item>
 						<Item to="/foo/meep/entityIdValue/two">
-							<Grid container justify="space-between">
+							<Grid container alignItems="center">
 								<Grid item>Translated</Grid>
 								<Grid item></Grid>
 							</Grid>
 						</Item>
 						<Item to="/foo/meep/entityIdValue/three">
-							<Grid container justify="space-between">
+							<Grid container alignItems="center">
 								<Grid item>
 									<TooltippedTypography children="ComponentLabel" titleValue="ComponentLabel" noWrap />
 								</Grid>
@@ -413,13 +413,13 @@ describe("SegmentPage", () => {
 							</Grid>
 						</Item>
 						<Item>
-							<Grid container justify="space-between">
+							<Grid container alignItems="center">
 								<Grid item>DisabledSection</Grid>
 								<Grid item></Grid>
 							</Grid>
 						</Item>
 						<Item>
-							<Grid container justify="space-between">
+							<Grid container alignItems="center">
 								<Grid item>DisabledSectionBySelector</Grid>
 								<Grid item></Grid>
 							</Grid>


### PR DESCRIPTION
Add ability to override styling for Badge and Popper components 
Prevent event bubbling when the Popper is the child of a Link <a>
Allow SearchControl to render without the Select component