### PR TITLE
Styling updates

### DIFF
--- a/src/components/MaterialUI/DataDisplay/PredefinedElements/InformationItem.js
+++ b/src/components/MaterialUI/DataDisplay/PredefinedElements/InformationItem.js
@@ -41,6 +41,9 @@ const useStyles = makeStyles(theme => ({
 	},
 	headerTextContainer: {
 		flexGrow: 0,
+		"& > $title": {
+			marginBottom: 0,
+		},
 	},
 	headerIconContainer: {
 		paddingLeft: theme.spacing(0.5),

--- a/src/components/MaterialUI/DataDisplay/PredefinedElements/InformationItem.js
+++ b/src/components/MaterialUI/DataDisplay/PredefinedElements/InformationItem.js
@@ -36,6 +36,8 @@ const useStyles = makeStyles(theme => ({
 	headerRoot: {
 		display: "flex",
 		flexDirection: "row",
+		alignItems: "center",
+		marginBottom: theme.spacing(1),
 	},
 	headerTextContainer: {
 		flexGrow: 0,
@@ -44,7 +46,7 @@ const useStyles = makeStyles(theme => ({
 		paddingLeft: theme.spacing(0.5),
 		display: "flex",
 		flexDirection: "column",
-		justifyContent: "center",
+		justifyContent: "flex-start",
 	},
 }));
 

--- a/src/components/MaterialUI/DataDisplay/Table.js
+++ b/src/components/MaterialUI/DataDisplay/Table.js
@@ -66,7 +66,7 @@ export const useStyles = makeStyles(theme => ({
 	},
 	tableCellSelect: {
 		padding: theme.spacing(2),
-		width: theme.spacing(5),
+		width: theme.spacing(3),
 	},
 	headerCell: {
 		padding: theme.spacing(1, 2),
@@ -75,7 +75,7 @@ export const useStyles = makeStyles(theme => ({
 	},
 	headerCellSelect: {
 		padding: theme.spacing(1, 2),
-		width: theme.spacing(5),
+		width: theme.spacing(3),
 		textAlign: "left",
 		fontWeight: theme.typography.fontWeightSemiBold,
 	},

--- a/src/components/MaterialUI/DataDisplay/Table.js
+++ b/src/components/MaterialUI/DataDisplay/Table.js
@@ -251,27 +251,35 @@ const buildTableRows = (
 		}
 	};
 
-	const mappedRows = rows.map(row => (
-		<MemoTableRow
-			className={classNames(classes.tableRow, customClasses.tableRow)}
-			key={row.key}
-			onClick={evt => onClick(evt, row)}
-			selected={selectionHandlers.isSelected(row.key)}
-			deepPropsComparation={deepPropsComparation}
-			context={context}
-			isEditingMode={isEditingMode}
-			dataRows={rows}
-		>
-			{selectMode === true ? buildRowCheckbox(classes, row.key, selectionHandlers) : null}
-			{row.columns.map((cell, cellIndex) => (
-				<TableCell
-					className={classNames(classes.tableCell, customClasses[cell.className], customClasses.tableCell)}
-					key={cellIndex}
-					value={cell.cellElement}
-				/>
-			))}
-		</MemoTableRow>
-	));
+	const mappedRows = rows.map(row => {
+		const customClassName = row.style.show ? row.style.customClass : "";
+		return (
+			<MemoTableRow
+				className={classNames(
+					classes.tableRow,
+					customClasses.tableRow,
+					customClasses[row.className],
+					customClasses[customClassName],
+				)}
+				key={row.key}
+				onClick={evt => onClick(evt, row)}
+				selected={selectionHandlers.isSelected(row.key)}
+				deepPropsComparation={deepPropsComparation}
+				context={context}
+				isEditingMode={isEditingMode}
+				dataRows={rows}
+			>
+				{selectMode === true ? buildRowCheckbox(classes, row.key, selectionHandlers) : null}
+				{row.columns.map((cell, cellIndex) => (
+					<TableCell
+						className={classNames(classes.tableCell, customClasses[cell.className], customClasses.tableCell)}
+						key={cellIndex}
+						value={cell.cellElement}
+					/>
+				))}
+			</MemoTableRow>
+		);
+	});
 
 	return mappedRows;
 };

--- a/src/components/MaterialUI/DataDisplay/Table.js
+++ b/src/components/MaterialUI/DataDisplay/Table.js
@@ -252,7 +252,9 @@ const buildTableRows = (
 	};
 
 	const mappedRows = rows.map(row => {
-		const customClassName = row.style.show ? row.style.customClass : "";
+		const showStyle = row?.style?.show ?? false;
+		const rowClass = row?.style?.customClass ?? "";
+		const customClassName = showStyle ? rowClass : "";
 		return (
 			<MemoTableRow
 				className={classNames(

--- a/src/components/MaterialUI/DataDisplay/Table.test.js
+++ b/src/components/MaterialUI/DataDisplay/Table.test.js
@@ -253,10 +253,10 @@ describe("Memoize components", () => {
 
 		const mountedComponent = mount(<Table headers={headers} rows={rows} />);
 
-		let mountedFirstHeaderSortOptions = mountedComponent.prop("headers")[0].cellElement.props.columnDefinition
-			.sortOptions;
-		let mountedSecondHeaderSortOptions = mountedComponent.prop("headers")[1].cellElement.props.columnDefinition
-			.sortOptions;
+		let mountedFirstHeaderSortOptions =
+			mountedComponent.prop("headers")[0].cellElement.props.columnDefinition.sortOptions;
+		let mountedSecondHeaderSortOptions =
+			mountedComponent.prop("headers")[1].cellElement.props.columnDefinition.sortOptions;
 
 		expect(mountedFirstHeaderSortOptions.sortField, "to be true");
 		expect(mountedSecondHeaderSortOptions.sortField, "to be false");
@@ -1071,5 +1071,23 @@ describe("Table", () => {
 
 		const tableInfo = mountedComponent.find(TableInfoBar);
 		expect(tableInfo.length, "to equal", 1);
+	});
+
+	it("Renders Table rows with custom classes if provided and allowed", () => {
+		const elements = [
+			{ id: "1", a1: "test11", a2: "test12", customClass: "specialClass" },
+			{ id: "2", a1: "test21", a2: "test22", customClass: "" },
+			{ id: "3", a1: "test31", a2: "test32" },
+		];
+
+		const { headers, rows } = buildHeaderAndRowFromConfig(config, elements, true, "id", true);
+		const component = <Table rows={rows} headers={headers} />;
+		const mountedComponent = mount(component);
+
+		const tableRows = mountedComponent.find(MemoTableRow);
+		const row1Props = tableRows.first().props();
+		const style = row1Props.dataRows[0].style;
+
+		expect(style.customClass, "to equal", "specialClass");
 	});
 });

--- a/src/components/MaterialUI/DataDisplay/tableHelpers.js
+++ b/src/components/MaterialUI/DataDisplay/tableHelpers.js
@@ -157,10 +157,11 @@ export const buildHeaderAndRowFromConfig = (
 
 	const rows = elements.map(e => {
 		const rowId = e[keyField];
+		const elementClass = e.customClass || "";
 		return {
 			key: rowId,
 			element: e,
-			style: { show: showCustomClass, customClass: e.customClass },
+			style: { show: showCustomClass, customClass: elementClass },
 			columns: columnDefinitions
 				.filter(def => def.visible !== false)
 				.map(def => {

--- a/src/components/MaterialUI/DataDisplay/tableHelpers.js
+++ b/src/components/MaterialUI/DataDisplay/tableHelpers.js
@@ -137,7 +137,13 @@ const renderByTypeInEditingMode = (e, def, rowId, readOnly, transformedValue) =>
 	return renderByType(e, def, rowId, readOnly, transformedValue);
 };
 
-export const buildHeaderAndRowFromConfig = (columnDefinitions, elements, readOnly = true, keyField = "id") => {
+export const buildHeaderAndRowFromConfig = (
+	columnDefinitions,
+	elements,
+	readOnly = true,
+	keyField = "id",
+	showCustomClass = false,
+) => {
 	if (columnDefinitions.filter(def => def.sortOptions != null && def.sortOptions.sortField).length > 1) {
 		throw new Error("Only one active sort column can exist at the same time");
 	}
@@ -154,6 +160,7 @@ export const buildHeaderAndRowFromConfig = (columnDefinitions, elements, readOnl
 		return {
 			key: rowId,
 			element: e,
+			style: { show: showCustomClass, customClass: e.customClass },
 			columns: columnDefinitions
 				.filter(def => def.visible !== false)
 				.map(def => {

--- a/src/components/MaterialUI/DataDisplay/tableHelpers.test.js
+++ b/src/components/MaterialUI/DataDisplay/tableHelpers.test.js
@@ -93,16 +93,18 @@ describe("table helpers buildHeaderAndRowFromConfig", () => {
 				test: "A text row 2",
 				another: "another 2",
 				extraneous: "Don't show 2",
+				customClass: "specialRow1",
 			},
 			{
 				id: "an_id3",
 				test: null,
 				another: null,
 				extraneous: "Don't show 2",
+				customClass: "specialRow2",
 			},
 		];
 
-		const { headers, rows } = buildHeaderAndRowFromConfig(columnDef, elements);
+		const { headers, rows } = buildHeaderAndRowFromConfig(columnDef, elements, true, "id", true);
 
 		expect(headers.length, "to equal", 2);
 		expect(headers[0].cellElement.props.columnDefinition, "to equal", columnDef[0]);
@@ -115,6 +117,15 @@ describe("table helpers buildHeaderAndRowFromConfig", () => {
 
 		expect(rows[0].key, "to equal", "an_id1");
 		expect(rows[0].element, "to equal", elements[0]);
+
+		expect(rows[0].style.show, "to equal", true);
+		expect(rows[0].style.customClass, "to equal", "");
+
+		expect(rows[1].style.show, "to equal", true);
+		expect(rows[1].style.customClass, "to equal", "specialRow1");
+
+		expect(rows[2].style.show, "to equal", true);
+		expect(rows[2].style.customClass, "to equal", "specialRow2");
 		expect(
 			rows[0].columns[0].cellElement,
 			"when mounted",

--- a/src/components/MaterialUI/hocs/withDeferredPopper.js
+++ b/src/components/MaterialUI/hocs/withDeferredPopper.js
@@ -101,6 +101,8 @@ const withDeferredPopper =
 			}
 		};
 
+		const placement = props?.placement ?? "bottom";
+
 		const classProp = props.classprop ? props.classprop : classes;
 
 		classProp.popperContainer = classProp.popperContainer ?? classes.popperContainer;
@@ -114,6 +116,7 @@ const withDeferredPopper =
 				<div className={classProp.popperContainer} data-qa="popperContainer">
 					{defaultComponent}
 					<Popper
+						placement={placement}
 						data-qa="poperComponent"
 						className={classProp.popper}
 						modifiers={{


### PR DESCRIPTION
Tables:
Update width of Table cells with select input
 - in header
 - in content
Allow custom Row styling in Table

InformationItem:
Fix the layout of the label that has a warning icon
Fix label styling to remove extra margin-bottom for input Labels

Popper:
Add the property **placement** to the wrapped Popper component with default "bottom" value