### PR TITLE
Resuming entity editing does not display modification indicators

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "orc-shared",
-	"version": "0.11.0-dev.203",
+	"version": "0.11.0-dev.204",
 	"description": "Shared code for Orckestra applications",
 	"main": "./src/index.js",
 	"exports": {

--- a/src/actions/view.js
+++ b/src/actions/view.js
@@ -1,12 +1,13 @@
 export const VIEW_SET = "VIEW_STATE_SET";
 export const VIEW_SET_FIELD = "VIEW_STATE_SET_FIELD";
 
-export const VIEW_CREATE_EDIT_NODE = "VIEW_CREATE_EDIT_NODE";
 export const VIEW_REMOVE_EDIT_NODE = "VIEW_REMOVE_EDIT_NODE";
 export const VIEW_SET_EDIT_MODEL_FIELD = "VIEW_SET_EDIT_MODEL_FIELD";
+export const VIEW_SET_FULL_ENTITY_EDIT_MODEL = "VIEW_SET_FULL_ENTITY_EDIT_MODEL";
 export const VIEW_SET_EDIT_MODEL_ERRORS = "VIEW_SET_EDIT_MODEL_ERRORS";
 export const VIEW_SET_EDIT_MODEL_FIELD_ERRORS = "VIEW_SET_EDIT_MODEL_FIELD_ERRORS";
 export const VIEW_REMOVE_EDIT_MODEL = "VIEW_REMOVE_EDIT_MODEL";
+export const VIEW_REMOVE_EDIT_ALL_MODEL_FIELDS = "VIEW_REMOVE_EDIT_ALL_MODEL_FIELDS";
 export const VIEW_REMOVE_EDIT_MODEL_FIELD_ERRORS = "VIEW_REMOVE_EDIT_MODEL_FIELD_ERRORS";
 export const VIEW_REMOVE_EDIT_MODEL_FIELD = "VIEW_REMOVE_EDIT_MODEL_FIELD";
 
@@ -33,6 +34,16 @@ export const removeEditModel = (keys, entityId, sectionName, moduleName) => ({
 export const setEditModelField = (keys, value, storeValue, entityId, sectionName, moduleName) => ({
 	type: VIEW_SET_EDIT_MODEL_FIELD,
 	payload: { keys, value, storeValue, entityId, sectionName, moduleName },
+});
+
+export const setFullEntityEditModel = (entityFullModel, moduleName) => ({
+	type: VIEW_SET_FULL_ENTITY_EDIT_MODEL,
+	payload: { entityFullModel, moduleName },
+});
+
+export const removeEditAllModelFields = (keys, entityId, sectionName, moduleName) => ({
+	type: VIEW_REMOVE_EDIT_ALL_MODEL_FIELDS,
+	payload: { keys, entityId, sectionName, moduleName },
 });
 
 export const removeEditModelField = (keys, storeValue, entityId, sectionName, moduleName) => ({

--- a/src/actions/view.test.js
+++ b/src/actions/view.test.js
@@ -1,3 +1,4 @@
+import Immutable from "immutable";
 import {
 	setValue,
 	setStateField,
@@ -11,6 +12,16 @@ import {
 	VIEW_REMOVE_EDIT_MODEL,
 	removeEditModelField,
 	VIEW_REMOVE_EDIT_MODEL_FIELD,
+	setFullEntityEditModel,
+	VIEW_SET_FULL_ENTITY_EDIT_MODEL,
+	removeEditAllModelFields,
+	VIEW_REMOVE_EDIT_ALL_MODEL_FIELDS,
+	setEditModelErrors,
+	VIEW_SET_EDIT_MODEL_ERRORS,
+	setEditModelFieldError,
+	VIEW_SET_EDIT_MODEL_FIELD_ERRORS,
+	removeEditModelFieldError,
+	VIEW_REMOVE_EDIT_MODEL_FIELD_ERRORS,
 } from "./view";
 
 describe("setValue", () => {
@@ -68,6 +79,42 @@ describe("setEditModelField", () => {
 	});
 });
 
+describe("setFullEntityEditModel", () => {
+	it("creates an action object", () => {
+		const fullModel = Immutable.fromJS({
+			a: 1,
+			b: "2222",
+		});
+		expect(setFullEntityEditModel, "when called with", [fullModel, "moduleName"], "to equal", {
+			type: VIEW_SET_FULL_ENTITY_EDIT_MODEL,
+			payload: {
+				entityFullModel: fullModel,
+				moduleName: "moduleName",
+			},
+		});
+	});
+});
+
+describe("removeEditAllModelFields", () => {
+	it("creates an action object", () => {
+		expect(
+			removeEditAllModelFields,
+			"when called with",
+			["keys", "entityId", "sectionName", "moduleName"],
+			"to equal",
+			{
+				type: VIEW_REMOVE_EDIT_ALL_MODEL_FIELDS,
+				payload: {
+					keys: "keys",
+					entityId: "entityId",
+					sectionName: "sectionName",
+					moduleName: "moduleName",
+				},
+			},
+		);
+	});
+});
+
 describe("removeEditModel", () => {
 	it("creates an action object", () => {
 		expect(removeEditModel, "when called with", ["keys", "entityId", "sectionName", "moduleName"], "to equal", {
@@ -94,6 +141,61 @@ describe("removeEditModelField", () => {
 				payload: {
 					keys: "keys",
 					storeValue: "storeValue",
+					entityId: "entityId",
+					sectionName: "sectionName",
+					moduleName: "moduleName",
+				},
+			},
+		);
+	});
+});
+
+describe("setEditModelErrors", () => {
+	it("creates an action object", () => {
+		expect(setEditModelErrors, "when called with", ["errors", "entityId", "sectionName", "moduleName"], "to equal", {
+			type: VIEW_SET_EDIT_MODEL_ERRORS,
+			payload: {
+				errors: "errors",
+				entityId: "entityId",
+				sectionName: "sectionName",
+				moduleName: "moduleName",
+			},
+		});
+	});
+});
+
+describe("setEditModelFieldError", () => {
+	it("creates an action object", () => {
+		expect(
+			setEditModelFieldError,
+			"when called with",
+			["keys", "error", "entityId", "sectionName", "moduleName"],
+			"to equal",
+			{
+				type: VIEW_SET_EDIT_MODEL_FIELD_ERRORS,
+				payload: {
+					keys: "keys",
+					error: "error",
+					entityId: "entityId",
+					sectionName: "sectionName",
+					moduleName: "moduleName",
+				},
+			},
+		);
+	});
+});
+
+describe("removeEditModelFieldError", () => {
+	it("creates an action object", () => {
+		expect(
+			removeEditModelFieldError,
+			"when called with",
+			["keys", "entityId", "sectionName", "moduleName"],
+			"to equal",
+			{
+				type: VIEW_REMOVE_EDIT_MODEL_FIELD_ERRORS,
+				payload: {
+					keys: "keys",
 					entityId: "entityId",
 					sectionName: "sectionName",
 					moduleName: "moduleName",

--- a/src/hooks/useEditState.js
+++ b/src/hooks/useEditState.js
@@ -27,7 +27,7 @@ export const useEditState = (entityId, sectionName, extendedValidationRules = {}
 		initialValue = "",
 		errorTypes = [],
 		saveInitialValueToEditState = false,
-		validateInitialValueAfterSave = false,
+		preValidateInitialValue = false,
 		fieldDependencies = {},
 	) => {
 		const stateValue = useSelectorAndUnwrap(state =>
@@ -62,11 +62,11 @@ export const useEditState = (entityId, sectionName, extendedValidationRules = {}
 			if (saveInitialValueToEditState && stateValue == null) {
 				dispatchWithModulesData(setEditModelField, [keys, initialValue, initialValue, entityId, sectionName]);
 
-				if (validateInitialValueAfterSave) {
+				if (preValidateInitialValue) {
 					isEditStateValid(initialValue);
 				}
 			}
-		}, [initialValue, keys, saveInitialValueToEditState, validateInitialValueAfterSave, stateValue, isEditStateValid]);
+		}, [initialValue, keys, saveInitialValueToEditState, preValidateInitialValue, stateValue, isEditStateValid]);
 
 		const updateEditState = (newValue, dependencies) => {
 			dispatchWithModulesData(setEditModelField, [keys, newValue, initialValue, entityId, sectionName]);
@@ -139,7 +139,6 @@ export const useDynamicEditState = (entityId, sectionName, extendedValidationRul
 
 			return result;
 		};
-
 		const hasAnyValidationErrors = (value, path, errorTypes, dependencies) => {
 			let hasAnyValidationErrors = false;
 			errorTypes.forEach(errorType => {

--- a/src/hooks/useEditState.test.js
+++ b/src/hooks/useEditState.test.js
@@ -53,13 +53,17 @@ describe("useEditState", () => {
 		};
 	});
 
-	const TestComp = ({ saveInitialValueToEditState = false }) => {
-		const createEditState = useEditState(entityId, sectionName, { customRule: value => value === "custom" });
+	const TestComp = ({ saveInitialValueToEditState = false, validateInitialValueAfterSave = false }) => {
+		const createEditState = useEditState(entityId, sectionName, {
+			customRule: (value, dependencies = { valid: true }) => value === "custom" && dependencies.valid,
+		});
+
 		const field = createEditState(
 			["field"],
 			initialFieldValue,
 			[validationErrorTypes.fieldIsRequired, "customRule"],
 			saveInitialValueToEditState,
+			validateInitialValueAfterSave,
 		);
 		const fieldWithUndefinedInitialValue = createEditState(["anotherField"]);
 
@@ -70,8 +74,10 @@ describe("useEditState", () => {
 			<div>
 				<div id="field">{field.state.value}</div>
 				<div id="fieldWithUndefinedInitialValue">{fieldWithUndefinedInitialValue.state.value}</div>
+				<div id="fieldWithUndefinedError">{fieldWithUndefinedInitialValue.state.error}</div>
 				<div id="update" onClick={e => field.update(e.target.value)} />
 				<div id="updateWithDefaultValidation" onClick={e => field.update(e.target.value)} />
+				<div id="updateWithDependencies" onClick={e => field.update(e.target.value, { valid: false })} />
 				<div id="updateWithCustomValidation" onClick={e => field.update(e.target.value)} />
 				<div id="reset" onClick={field.reset} />
 				<div id="isValid" onClick={field.isValid} />
@@ -159,9 +165,60 @@ describe("useEditState", () => {
 
 		mount(component);
 
-		expect(useDispatchWithModulesDataSpy, "to have a call satisfying", {
-			args: [setEditModelField, [["field"], initialFieldValue, initialFieldValue, entityId, sectionName]],
-		});
+		expect(useDispatchWithModulesDataSpy, "to have calls satisfying", [
+			{
+				args: [setEditModelField, [["field"], initialFieldValue, initialFieldValue, entityId, sectionName]],
+			},
+		]);
+
+		useDispatchWithModulesDataStub.restore();
+	});
+
+	it("Not validates initial value to edit state if validateInitialValueAfterSave is false", () => {
+		const component = (
+			<TestWrapper provider={{ store }}>
+				<TestComp saveInitialValueToEditState />
+			</TestWrapper>
+		);
+
+		const useDispatchWithModulesDataSpy = sinon.spy();
+		const useDispatchWithModulesDataStub = sinon
+			.stub(useDispatchWithModulesDataMock, "useDispatchWithModulesData")
+			.returns(useDispatchWithModulesDataSpy);
+
+		mount(component);
+
+		expect(useDispatchWithModulesDataSpy, "to have calls satisfying", [
+			{
+				args: [setEditModelField, [["field"], initialFieldValue, initialFieldValue, entityId, sectionName]],
+			},
+		]);
+
+		useDispatchWithModulesDataStub.restore();
+	});
+
+	it("Validates initial value to edit state if validateInitialValueAfterSave is true", () => {
+		const component = (
+			<TestWrapper provider={{ store }}>
+				<TestComp saveInitialValueToEditState validateInitialValueAfterSave />
+			</TestWrapper>
+		);
+
+		const useDispatchWithModulesDataSpy = sinon.spy();
+		const useDispatchWithModulesDataStub = sinon
+			.stub(useDispatchWithModulesDataMock, "useDispatchWithModulesData")
+			.returns(useDispatchWithModulesDataSpy);
+
+		mount(component);
+
+		expect(useDispatchWithModulesDataSpy, "to have calls satisfying", [
+			{
+				args: [setEditModelField, [["field"], initialFieldValue, initialFieldValue, entityId, sectionName]],
+			},
+			{
+				args: [setEditModelFieldError, [["field"], "customRule", entityId, sectionName]],
+			},
+		]);
 
 		useDispatchWithModulesDataStub.restore();
 	});
@@ -227,6 +284,41 @@ describe("useEditState", () => {
 
 		expect(useDispatchWithModulesDataSpy, "to have no calls satisfying", {
 			args: [setEditModelFieldError, [["field"], validationErrorTypes.fieldIsRequired, entityId, sectionName]],
+		});
+
+		useDispatchWithModulesDataStub.restore();
+	});
+
+	it("Updates edit view value correctly with default validation rules when validation was passed with dependencies", () => {
+		const component = (
+			<TestWrapper provider={{ store }}>
+				<TestComp />
+			</TestWrapper>
+		);
+
+		const useDispatchWithModulesDataSpy = sinon.spy();
+		const useDispatchWithModulesDataStub = sinon
+			.stub(useDispatchWithModulesDataMock, "useDispatchWithModulesData")
+			.returns(useDispatchWithModulesDataSpy);
+
+		const mountedComponent = mount(component);
+
+		const fieldComponent = mountedComponent.find("#updateWithDependencies");
+
+		const event = {
+			target: {
+				value: "newValue",
+			},
+		};
+
+		fieldComponent.invoke("onClick")(event);
+
+		expect(useDispatchWithModulesDataSpy, "to have a call satisfying", {
+			args: [setEditModelField, [["field"], "newValue", initialFieldValue, entityId, sectionName]],
+		});
+
+		expect(useDispatchWithModulesDataSpy, "to have a call satisfying", {
+			args: [setEditModelFieldError, [["field"], "customRule", entityId, sectionName]],
 		});
 
 		useDispatchWithModulesDataStub.restore();

--- a/src/hooks/useFullEntityEditState.js
+++ b/src/hooks/useFullEntityEditState.js
@@ -25,7 +25,6 @@ export const useFullEntityEditState = (
 
 			if (isValid === false && error == null) {
 				error = errorType;
-				return;
 			}
 		});
 

--- a/src/hooks/useFullEntityEditState.js
+++ b/src/hooks/useFullEntityEditState.js
@@ -8,7 +8,7 @@ import { isEqual } from "lodash";
 // as properties of extendedValidationRules
 export const useFullEntityEditState = (
 	entityId,
-	getFullEntityModelProperties = null,
+	getFullEntityModelProperties,
 	extendedValidationRules = {},
 	dependencies = {},
 ) => {
@@ -23,7 +23,7 @@ export const useFullEntityEditState = (
 				? mergedValidationRules[errorType](newValue, dependencies)
 				: true;
 
-			if (isValid === false) {
+			if (isValid === false && error == null) {
 				error = errorType;
 				return;
 			}
@@ -37,29 +37,8 @@ export const useFullEntityEditState = (
 
 		const fullEntityModelProperties = getFullEntityModelProperties(initializationContext ?? {});
 
-		for (const sectionName in fullEntityModelProperties) {
-			if (!fullEntityModelProperties.hasOwnProperty(sectionName)) {
-				continue;
-			}
-
-			const editStateFieldDefinitions = fullEntityModelProperties[sectionName];
-
-			for (const fieldName in editStateFieldDefinitions) {
-				if (!editStateFieldDefinitions.hasOwnProperty(fieldName)) {
-					continue;
-				}
-
-				const fieldDefinition = editStateFieldDefinitions[fieldName];
-
-				console.log(
-					"ResumeFunction --->  ",
-					fieldName,
-					"  ---> ",
-					fieldDefinition.newValue,
-					"   :::::  ",
-					fieldDefinition.initialValue,
-				);
-
+		Object.entries(fullEntityModelProperties).forEach(([sectionName, editStateFieldDefinitions]) => {
+			Object.entries(editStateFieldDefinitions).forEach(([fieldName, fieldDefinition]) => {
 				const allDependencies = {
 					...dependencies,
 					...fieldDefinition.dependencies,
@@ -79,8 +58,8 @@ export const useFullEntityEditState = (
 				const path = [entityId, sectionName, "model"].concat(fieldDefinition.keys);
 
 				fullEntityEditModel = fullEntityEditModel.setIn(path, value);
-			}
-		}
+			});
+		});
 
 		dispatchWithModulesData(setFullEntityEditModel, [fullEntityEditModel]);
 	};

--- a/src/hooks/useFullEntityEditState.js
+++ b/src/hooks/useFullEntityEditState.js
@@ -1,0 +1,91 @@
+import Immutable from "immutable";
+import { useDispatchWithModulesData } from "./../hooks/useDispatchWithModulesData";
+import { setFullEntityEditModel } from "./../actions/view";
+import { validationRules } from "../utils/modelValidationHelper";
+import { isEqual } from "lodash";
+
+// if you need to override default validation rules just pass new rules with default keys
+// as properties of extendedValidationRules
+export const useFullEntityEditState = (
+	entityId,
+	getFullEntityModelProperties = null,
+	extendedValidationRules = {},
+	dependencies = {},
+) => {
+	const dispatchWithModulesData = useDispatchWithModulesData();
+
+	const mergedValidationRules = { ...validationRules, ...extendedValidationRules };
+
+	const isEditStateValid = (newValue, errorTypes, dependencies) => {
+		let error = null;
+		errorTypes.forEach(errorType => {
+			const isValid = mergedValidationRules[errorType]
+				? mergedValidationRules[errorType](newValue, dependencies)
+				: true;
+
+			if (isValid === false) {
+				error = errorType;
+				return;
+			}
+		});
+
+		return error;
+	};
+
+	const buildFullEntityEditState = initializationContext => {
+		let fullEntityEditModel = Immutable.fromJS({});
+
+		const fullEntityModelProperties = getFullEntityModelProperties(initializationContext ?? {});
+
+		for (const sectionName in fullEntityModelProperties) {
+			if (!fullEntityModelProperties.hasOwnProperty(sectionName)) {
+				continue;
+			}
+
+			const editStateFieldDefinitions = fullEntityModelProperties[sectionName];
+
+			for (const fieldName in editStateFieldDefinitions) {
+				if (!editStateFieldDefinitions.hasOwnProperty(fieldName)) {
+					continue;
+				}
+
+				const fieldDefinition = editStateFieldDefinitions[fieldName];
+
+				console.log(
+					"ResumeFunction --->  ",
+					fieldName,
+					"  ---> ",
+					fieldDefinition.newValue,
+					"   :::::  ",
+					fieldDefinition.initialValue,
+				);
+
+				const allDependencies = {
+					...dependencies,
+					...fieldDefinition.dependencies,
+				};
+
+				const error = isEditStateValid(fieldDefinition.newValue, fieldDefinition.errorTypes ?? [], allDependencies);
+
+				const value = {
+					value: fieldDefinition.newValue,
+					wasModified: !isEqual(fieldDefinition.initialValue, fieldDefinition.newValue),
+				};
+
+				if (error) {
+					value.error = error;
+				}
+
+				const path = [entityId, sectionName, "model"].concat(fieldDefinition.keys);
+
+				fullEntityEditModel = fullEntityEditModel.setIn(path, value);
+			}
+		}
+
+		dispatchWithModulesData(setFullEntityEditModel, [fullEntityEditModel]);
+	};
+
+	return buildFullEntityEditState;
+};
+
+export default useFullEntityEditState;

--- a/src/hooks/useFullEntityEditState.test.js
+++ b/src/hooks/useFullEntityEditState.test.js
@@ -4,19 +4,100 @@ import Immutable from "immutable";
 import sinon from "sinon";
 import { mount } from "enzyme";
 import { useFullEntityEditState } from "./useFullEntityEditState";
+import * as useDispatchWithModulesDataMock from "./useDispatchWithModulesData";
+import { setFullEntityEditModel } from "../actions/view";
 
 describe("useFullEntityEditState", () => {
-	let store, state;
+	let store, state, useDispatchWithModulesDataSpy, useDispatchWithModulesDataStub;
 	const moduleName = "thing";
 	const sectionName = "mySection";
 	const entityId = "entityId";
-	const initialFieldValue = "initialValue";
-	const model = {
-		value: "fieldValue",
+
+	const getFullEntityModelProperties = context => {
+		return {
+			section1: {
+				field1_S1: {
+					keys: ["field1_S1"],
+					initialValue: "val1",
+					newValue: "val1",
+				},
+				field2_S1: {
+					keys: ["field2_S1"],
+					initialValue: "old_custom",
+					errorTypes: ["customRule"],
+					newValue: context?.field2_S1_value ?? "not_custom",
+				},
+			},
+			section2: {
+				field1_S2: {
+					keys: ["id_S2", "field1_S2"],
+					initialValue: { a: 1, b: "F1_S2" },
+					newValue: { a: 1, b: "F1_S2_MODIFIED" },
+				},
+				field2_S2: {
+					keys: ["field2_S2"],
+					initialValue: 5,
+					newValue: 5,
+				},
+				field3_S2: {
+					keys: ["field3_S2"],
+					initialValue: "init",
+					newValue: "new",
+				},
+			},
+		};
 	};
-	// const buildContext = (context) => {
-	//     //const
-	// };
+
+	const field2_S1_WithError = {
+		value: "not_custom",
+		wasModified: true,
+		error: "customRule",
+	};
+
+	const field2_S1_WithDependencyError = {
+		value: "custom",
+		wasModified: true,
+		error: "customRule",
+	};
+
+	const moduleStateAfterInit = {
+		[entityId]: {
+			section1: {
+				model: {
+					field1_S1: {
+						value: "val1",
+						wasModified: false,
+					},
+					field2_S1: {
+						value: "not_custom",
+						wasModified: true,
+					},
+				},
+			},
+			section2: {
+				model: {
+					id_S2: {
+						field1_S2: {
+							value: { a: 1, b: "F1_S2_MODIFIED" },
+							wasModified: true,
+						},
+					},
+					field2_S2: {
+						value: 5,
+						wasModified: false,
+					},
+					field3_S2: {
+						value: "new",
+						wasModified: true,
+					},
+				},
+			},
+		},
+	};
+
+	const validationRules = {
+		customRule: (value, dependencies = { valid: true }) => value === "custom" && dependencies.valid,
+	};
 
 	beforeEach(() => {
 		state = Immutable.fromJS({
@@ -25,19 +106,14 @@ describe("useFullEntityEditState", () => {
 				config: { prependPath: "/:scope/", prependHref: "/scope/" },
 			},
 			view: {
-				edit: {
-					[moduleName]: {
-						[entityId]: {
-							[sectionName]: {
-								field: {
-									model,
-								},
-							},
-						},
-					},
-				},
+				edit: {},
 			},
 		});
+
+		useDispatchWithModulesDataSpy = sinon.spy();
+		useDispatchWithModulesDataStub = sinon
+			.stub(useDispatchWithModulesDataMock, "useDispatchWithModulesData")
+			.returns(useDispatchWithModulesDataSpy);
 
 		store = {
 			subscribe: () => {},
@@ -46,33 +122,26 @@ describe("useFullEntityEditState", () => {
 		};
 	});
 
-	const TestComp = ({ context }) => {
+	afterEach(() => {
+		useDispatchWithModulesDataStub.restore();
+	});
+
+	const TestComp = ({ context, validationRules, dependencies }) => {
 		const initialization = useFullEntityEditState(
 			entityId,
-			sectionName,
-			{ customRule: (value, dependencies = { valid: true }) => value === "custom" && dependencies.valid },
-			{ dependency1: 1, dependency2: "two" },
+			getFullEntityModelProperties,
+			validationRules,
+			dependencies,
 		);
-
-		initialization(context);
 
 		return (
 			<div>
-				{/*<div id="field">{field.state.value}</div>*/}
-				{/*<div id="fieldWithUndefinedInitialValue">{fieldWithUndefinedInitialValue.state.value}</div>*/}
-				{/*<div id="fieldWithUndefinedError">{fieldWithUndefinedInitialValue.state.error}</div>*/}
-				{/*<div id="update" onClick={e => field.update(e.target.value)} />*/}
-				{/*<div id="updateWithDefaultValidation" onClick={e => field.update(e.target.value)} />*/}
-				{/*<div id="updateWithDependencies" onClick={e => field.update(e.target.value, { valid: false})} />*/}
-				{/*<div id="updateWithCustomValidation" onClick={e => field.update(e.target.value)} />*/}
-				{/*<div id="reset" onClick={field.reset} />*/}
-				{/*<div id="isValid" onClick={field.isValid} />*/}
-				{/*<div id="fieldWithoutValidation" onClick={e => fieldWithoutVaidationRules.update(e.target.value)} />*/}
+				<div id="initialize" onClick={() => initialization(context)} />
 			</div>
 		);
 	};
 
-	it("Provides an access to initial value in edit view", () => {
+	it("Initialize properly the full entity edit state", () => {
 		const component = (
 			<TestWrapper provider={{ store }}>
 				<TestComp />
@@ -81,8 +150,62 @@ describe("useFullEntityEditState", () => {
 
 		const mountedComponent = mount(component);
 
-		const fieldValue = mountedComponent.find("#field").prop("children");
+		const fieldComponent = mountedComponent.find("#initialize");
 
-		expect(fieldValue, "to equal", initialFieldValue);
+		fieldComponent.invoke("onClick")();
+
+		expect(useDispatchWithModulesDataSpy, "to have calls satisfying", [
+			{
+				args: [setFullEntityEditModel, [Immutable.fromJS(moduleStateAfterInit)]],
+			},
+		]);
+	});
+
+	it("Initialize properly the full entity edit state with validations", () => {
+		const component = (
+			<TestWrapper provider={{ store }}>
+				<TestComp validationRules={validationRules} />
+			</TestWrapper>
+		);
+
+		moduleStateAfterInit[entityId].section1.model.field2_S1 = field2_S1_WithError;
+
+		const mountedComponent = mount(component);
+
+		const fieldComponent = mountedComponent.find("#initialize");
+
+		fieldComponent.invoke("onClick")();
+
+		expect(useDispatchWithModulesDataSpy, "to have calls satisfying", [
+			{
+				args: [setFullEntityEditModel, [Immutable.fromJS(moduleStateAfterInit)]],
+			},
+		]);
+	});
+
+	it("Initialize properly the full entity edit state with validations and dependencies", () => {
+		const component = (
+			<TestWrapper provider={{ store }}>
+				<TestComp
+					context={{ field2_S1_value: "custom" }}
+					validationRules={validationRules}
+					dependencies={{ valid: false }}
+				/>
+			</TestWrapper>
+		);
+
+		moduleStateAfterInit[entityId].section1.model.field2_S1 = field2_S1_WithDependencyError;
+
+		const mountedComponent = mount(component);
+
+		const fieldComponent = mountedComponent.find("#initialize");
+
+		fieldComponent.invoke("onClick")();
+
+		expect(useDispatchWithModulesDataSpy, "to have calls satisfying", [
+			{
+				args: [setFullEntityEditModel, [Immutable.fromJS(moduleStateAfterInit)]],
+			},
+		]);
 	});
 });

--- a/src/hooks/useFullEntityEditState.test.js
+++ b/src/hooks/useFullEntityEditState.test.js
@@ -1,0 +1,88 @@
+import React from "react";
+import { TestWrapper } from "./../utils/testUtils";
+import Immutable from "immutable";
+import sinon from "sinon";
+import { mount } from "enzyme";
+import { useFullEntityEditState } from "./useFullEntityEditState";
+
+describe("useFullEntityEditState", () => {
+	let store, state;
+	const moduleName = "thing";
+	const sectionName = "mySection";
+	const entityId = "entityId";
+	const initialFieldValue = "initialValue";
+	const model = {
+		value: "fieldValue",
+	};
+	// const buildContext = (context) => {
+	//     //const
+	// };
+
+	beforeEach(() => {
+		state = Immutable.fromJS({
+			navigation: {
+				route: { match: { path: `/:scope/${moduleName}/id/${sectionName}` } },
+				config: { prependPath: "/:scope/", prependHref: "/scope/" },
+			},
+			view: {
+				edit: {
+					[moduleName]: {
+						[entityId]: {
+							[sectionName]: {
+								field: {
+									model,
+								},
+							},
+						},
+					},
+				},
+			},
+		});
+
+		store = {
+			subscribe: () => {},
+			dispatch: () => sinon.spy(),
+			getState: () => state,
+		};
+	});
+
+	const TestComp = ({ context }) => {
+		const initialization = useFullEntityEditState(
+			entityId,
+			sectionName,
+			{ customRule: (value, dependencies = { valid: true }) => value === "custom" && dependencies.valid },
+			{ dependency1: 1, dependency2: "two" },
+		);
+
+		initialization(context);
+
+		return (
+			<div>
+				{/*<div id="field">{field.state.value}</div>*/}
+				{/*<div id="fieldWithUndefinedInitialValue">{fieldWithUndefinedInitialValue.state.value}</div>*/}
+				{/*<div id="fieldWithUndefinedError">{fieldWithUndefinedInitialValue.state.error}</div>*/}
+				{/*<div id="update" onClick={e => field.update(e.target.value)} />*/}
+				{/*<div id="updateWithDefaultValidation" onClick={e => field.update(e.target.value)} />*/}
+				{/*<div id="updateWithDependencies" onClick={e => field.update(e.target.value, { valid: false})} />*/}
+				{/*<div id="updateWithCustomValidation" onClick={e => field.update(e.target.value)} />*/}
+				{/*<div id="reset" onClick={field.reset} />*/}
+				{/*<div id="isValid" onClick={field.isValid} />*/}
+				{/*<div id="fieldWithoutValidation" onClick={e => fieldWithoutVaidationRules.update(e.target.value)} />*/}
+			</div>
+		);
+	};
+
+	it("Provides an access to initial value in edit view", () => {
+		const component = (
+			<TestWrapper provider={{ store }}>
+				<TestComp />
+			</TestWrapper>
+		);
+
+		const mountedComponent = mount(component);
+
+		const fieldValue = mountedComponent.find("#field").prop("children");
+
+		expect(fieldValue, "to equal", initialFieldValue);
+	});
+});

--- a/src/reducers/view.js
+++ b/src/reducers/view.js
@@ -4,11 +4,13 @@ import {
 	VIEW_SET_FIELD,
 	VIEW_REMOVE_EDIT_NODE,
 	VIEW_SET_EDIT_MODEL_FIELD,
+	VIEW_SET_FULL_ENTITY_EDIT_MODEL,
 	VIEW_SET_EDIT_MODEL_FIELD_ERRORS,
 	VIEW_SET_EDIT_MODEL_ERRORS,
 	VIEW_REMOVE_EDIT_MODEL,
 	VIEW_REMOVE_EDIT_MODEL_FIELD_ERRORS,
 	VIEW_REMOVE_EDIT_MODEL_FIELD,
+	VIEW_REMOVE_EDIT_ALL_MODEL_FIELDS,
 } from "../actions/view";
 import { APPLICATION_SCOPE_HAS_CHANGED } from "../actions/scopes";
 import { isEqual, dropRight } from "lodash";
@@ -41,7 +43,18 @@ const viewStateReducer = (state = initialState, action) => {
 
 			const path = ["edit", moduleName, entityId, sectionName, "model"].concat(keys);
 
-			return state.setIn(path, Immutable.fromJS({ value, wasModified: !isEqual(value, storeValue) }));
+			return state.setIn(
+				path,
+				Immutable.fromJS({
+					value,
+					wasModified: !isEqual(value, storeValue),
+				}),
+			);
+		}
+		case VIEW_SET_FULL_ENTITY_EDIT_MODEL: {
+			const { entityFullModel, moduleName } = action.payload;
+
+			return state.setIn(["edit", moduleName], entityFullModel);
 		}
 		case VIEW_REMOVE_EDIT_MODEL_FIELD: {
 			const { keys, storeValue, entityId, sectionName, moduleName } = action.payload;
@@ -57,6 +70,13 @@ const viewStateReducer = (state = initialState, action) => {
 			const unpackedValue = mapModifiedData(value.toJS());
 
 			return state.setIn(pathToUpdate, Immutable.fromJS({ value, wasModified: !isEqual(unpackedValue, storeValue) }));
+		}
+		case VIEW_REMOVE_EDIT_ALL_MODEL_FIELDS: {
+			const { keys, entityId, sectionName, moduleName } = action.payload;
+
+			const pathToDelete = ["edit", moduleName, entityId, sectionName, "model"].concat(keys);
+
+			return state.removeIn(pathToDelete);
 		}
 		case VIEW_SET_EDIT_MODEL_FIELD_ERRORS: {
 			const { keys, error, entityId, sectionName, moduleName } = action.payload;

--- a/src/reducers/view.test.js
+++ b/src/reducers/view.test.js
@@ -9,6 +9,8 @@ import {
 	removeEditModel,
 	removeEditModelFieldError,
 	removeEditModelField,
+	setFullEntityEditModel,
+	removeEditAllModelFields,
 } from "../actions/view";
 import viewReducer from "./view";
 import { applicationScopeHasChanged } from "../actions/scopes";
@@ -97,6 +99,55 @@ describe("View state reducer", () => {
 		};
 
 		const action = setEditModelField(keys, newValue, oldValue, entityId, sectionName, moduleName);
+		const newState = viewReducer(oldState, action);
+
+		return expect(newState, "not to be", oldState).and("to equal", Immutable.fromJS({ edit: expected }));
+	});
+
+	it("Sets full entity edit model correctly", () => {
+		const newValue = "newValue";
+		const moduleName = "module1";
+
+		const modules = Immutable.fromJS({
+			[moduleName]: {},
+		});
+
+		const oldState = Immutable.Map({
+			edit: modules,
+		});
+
+		const entityModel = {
+			entityOne: {
+				sectionOne: {
+					key1: {
+						key2: {
+							key3: {
+								value: newValue,
+								wasModified: true,
+							},
+						},
+					},
+				},
+				sectionTwo: {
+					key1: {
+						key2: {
+							key3: {
+								value: newValue,
+								wasModified: true,
+							},
+						},
+					},
+				},
+			},
+		};
+
+		const expected = {
+			[moduleName]: {
+				entityOne: entityModel.entityOne,
+			},
+		};
+
+		const action = setFullEntityEditModel(Immutable.fromJS(entityModel), moduleName);
 		const newState = viewReducer(oldState, action);
 
 		return expect(newState, "not to be", oldState).and("to equal", Immutable.fromJS({ edit: expected }));
@@ -323,6 +374,57 @@ describe("View state reducer", () => {
 		return expect(newState, "not to be", oldState).and("to equal", Immutable.Map({ edit: expected }));
 	});
 
+	it("Remove field error inside model correctly", () => {
+		const keys = ["key1", "key2", "key3"];
+		const error = "error";
+		const entityId = "entityId";
+		const moduleName = "module1";
+		const sectionName = "section11";
+
+		const oldState = Immutable.fromJS({
+			edit: {
+				[moduleName]: {
+					[entityId]: {
+						[sectionName]: {
+							model: {
+								key1: {
+									key2: {
+										key3: {
+											error: error,
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		});
+
+		const model = {
+			key1: {
+				key2: {
+					key3: {},
+				},
+			},
+		};
+
+		const expected = Immutable.fromJS({
+			[moduleName]: {
+				[entityId]: {
+					[sectionName]: {
+						model,
+					},
+				},
+			},
+		});
+
+		const action = removeEditModelFieldError(keys, entityId, sectionName, moduleName);
+		const newState = viewReducer(oldState, action);
+
+		return expect(newState, "not to be", oldState).and("to equal", Immutable.Map({ edit: expected }));
+	});
+
 	it("Sets all errors inside model correctly", () => {
 		const errors = [
 			{ keys: ["key1", "key12", "key13"], error: "error1" },
@@ -476,6 +578,49 @@ describe("View state reducer", () => {
 		};
 
 		const action = removeEditModelField(keys, null, entityId, sectionName, moduleName);
+		const newState = viewReducer(oldState, action);
+
+		return expect(newState, "not to be", oldState).and("to equal", Immutable.fromJS({ edit: expected }));
+	});
+
+	it("Removes edit all model fields correctly", () => {
+		const entityId = "entityId";
+		const moduleName = "module1";
+		const sectionName = "sectionName2";
+		const keys = ["id"];
+
+		const modules = Immutable.fromJS({
+			[moduleName]: {
+				[entityId]: {
+					[sectionName]: {
+						model: {
+							id: {
+								prop1: {
+									prop3: {},
+								},
+								prop2: {},
+							},
+						},
+					},
+				},
+			},
+		});
+
+		const oldState = Immutable.Map({
+			edit: modules,
+		});
+
+		const expected = {
+			[moduleName]: {
+				[entityId]: {
+					[sectionName]: {
+						model: {},
+					},
+				},
+			},
+		};
+
+		const action = removeEditAllModelFields(keys, entityId, sectionName, moduleName);
 		const newState = viewReducer(oldState, action);
 
 		return expect(newState, "not to be", oldState).and("to equal", Immutable.fromJS({ edit: expected }));


### PR DESCRIPTION
- Resuming entity editing does not display modification indicators
- Run validations when required and when saving initial value in edit state
- Add ability to fully remove a portion of the edit state


Story: #46785