### PR TITLE
Allow SelectionList to reset on new list

### DIFF
--- a/src/components/MaterialUI/DataDisplay/SelectionList.js
+++ b/src/components/MaterialUI/DataDisplay/SelectionList.js
@@ -72,10 +72,18 @@ const SelectionList = ({
 	const defaultPanel = <div></div>;
 
 	useEffect(() => {
-		if (defaultSelection && checked.length === 0) {
+		const listDataIds = listData.data.map(d => d.id);
+		const checkedFromList = listDataIds.filter(l => checked.includes(l));
+		if (defaultSelection && checkedFromList.length === 0) {
 			setChecked([defaultSelection]);
 		}
-	}, [defaultSelection, checked.length]);
+	}, [defaultSelection, checked, listData.data]);
+
+	useEffect(() => {
+		if (!multiSelect) {
+			setChecked([defaultSelection]);
+		}
+	}, [defaultSelection, multiSelect, listData.data.length]);
 
 	const onChangeEvent = ids => {
 		onChange && onChange(formatOnChange(listData.data, ids));

--- a/src/components/MaterialUI/DataDisplay/SelectionList.test.js
+++ b/src/components/MaterialUI/DataDisplay/SelectionList.test.js
@@ -46,6 +46,33 @@ describe("SelectionList", () => {
 		expect(component, "when mounted", "to satisfy", expected);
 	});
 
+	it("Renders SelectionList correctly with multiSelect", () => {
+		const component = (
+			<TestWrapper intlProvider={{ messages }}>
+				<SelectionList
+					listData={{ title: listTitle, data: [{ id: "id1", disabled: true, title: "item1" }] }}
+					multiSelect={true}
+				/>
+			</TestWrapper>
+		);
+
+		const expected = (
+			<TestWrapper intlProvider={{ messages }}>
+				<Grid>
+					<Grid>
+						<div>{listTitle}</div>
+						<ScrollableCustomList checked={[]} items={list} classes={{}} />
+					</Grid>
+					<Grid>
+						<div></div>
+					</Grid>
+				</Grid>
+			</TestWrapper>
+		);
+
+		expect(component, "when mounted", "to satisfy", expected);
+	});
+
 	it("Renders SelectionList correctly if infoPanel is supplied", () => {
 		const component = (
 			<TestWrapper intlProvider={{ messages }}>
@@ -142,7 +169,7 @@ describe("SelectionList", () => {
 		let item = mountedComponent.find(ListItem).at(0);
 		item.invoke("onClick")();
 
-		expect(onChange.args[1][0], "to equal", { selectedItems: [list[0]] });
+		expect(onChange.args[2][0], "to equal", { selectedItems: [list[0]] });
 	});
 
 	it("Calls onChange with defaultSelection", () => {


### PR DESCRIPTION
- Allow SelectionList to reset on new list
- Reset selection if id does not exist
- 
Story [AB#48485](https://dev.azure.com/orckestra001/da965986-c85b-43be-9915-219568b000e5/_workitems/edit/48485)