### PR TITLE
Add new useRequestState and useNotificationRequestState hooks

### DIFF
--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -17,3 +17,11 @@ Returns `[flag, toggle(), reset()]` of a flag value with toggle and reset functi
 ## `useViewState(name)`
 
 Returns `[viewState, updateViewState(key, value)]`, where the former is the data stored by [the `view` reducer](actionsreducersselectors.md#view) for the given `name`, and the latter can be used to update individual key/value sets within it.
+
+## `useRequestState({ keys, operation, successAction, errorAction })`
+
+This hook is used to handle custom action after deletes and updates requests. Returns `[buildRequestState]`, where the first value is a method used to build the requestState object.
+
+## `useNotificationRequestState({ keys, operation, successAction, errorAction })`
+
+This hook is used to handle the notification message for deletes and updates. Returns `[buildRequestState]`, where the first value is a method used to build the requestState object.

--- a/src/actions/requestState.js
+++ b/src/actions/requestState.js
@@ -1,0 +1,8 @@
+export const RESET_REQUEST_STATE = "RESET_REQUEST_STATE";
+
+export const resetRequestState = (keys, operation) => ({
+	type: RESET_REQUEST_STATE,
+	meta: {
+		requestState: { keys, operation },
+	},
+});

--- a/src/actions/requestState.test.js
+++ b/src/actions/requestState.test.js
@@ -1,0 +1,14 @@
+import { RESET_REQUEST_STATE, resetRequestState } from "./requestState";
+
+describe("resetRequestState", () => {
+	it("creates a reset requestState action", () =>
+		expect(resetRequestState, "when called with", [["key1", "key2"], "the operation"], "to equal", {
+			type: RESET_REQUEST_STATE,
+			meta: {
+				requestState: {
+					keys: ["key1", "key2"],
+					operation: "the operation",
+				},
+			},
+		}));
+});

--- a/src/buildStore.js
+++ b/src/buildStore.js
@@ -19,6 +19,7 @@ import countriesReducer from "./reducers/countries";
 import timezonesReducer from "./reducers/timezones";
 import modulesReducer from "./reducers/modules";
 import metadataReducer from "./reducers/metadata";
+import requestStatesReducer from "./reducers/requestStates";
 
 window.BUILD_ID = BUILD_ID;
 window.BUILD_NUMBER = BUILD_NUMBER;
@@ -63,6 +64,7 @@ const buildStore = (reducers, devOptions = {}) => {
 			timezones: timezonesReducer,
 			modules: modulesReducer,
 			metadata: metadataReducer,
+			requestStates: requestStatesReducer,
 		});
 	const rootReducer = buildReducer(reducers);
 

--- a/src/constants.js
+++ b/src/constants.js
@@ -77,3 +77,12 @@ export const definitionType = {
 	shared: "Shared",
 	embedded: "Embedded",
 };
+
+export const requestStateOperations = {
+	delete: "delete",
+	update: "update",
+};
+export const requestStateOperationMap = {
+	delete: "deletes",
+	update: "updates",
+};

--- a/src/hooks/useNotificationRequestState.js
+++ b/src/hooks/useNotificationRequestState.js
@@ -1,0 +1,69 @@
+import { useIntl } from "react-intl";
+import { useCallback, useContext } from "react";
+import { NotificationContext } from "../components/MaterialUI/Feedback/NotificationContext";
+import useRequestState from "./useRequestState";
+
+/*
+    This hook is used to handle the notification message for deletes and updates.
+    It uses useRequestState internally to know when to display messages.
+
+    This hook returns a method used to build a requestState object that is used in the meta data property of the dispatched action.
+    The expected format for the action is as follow:
+    {
+        type: 'some type',
+        ... // other properties
+        meta: {
+            requestState: {
+                keys: [],
+                operation: requestStateOperations.delete
+            }
+        }
+    }
+*/
+
+const useNotificationRequestState = ({
+	keys,
+	operation,
+	successMessageId,
+	successMessageValues,
+	successAction,
+	errorMessageId,
+	errorMessageValues,
+	errorAction,
+}) => {
+	const { formatMessage } = useIntl();
+	const { addNotification } = useContext(NotificationContext);
+
+	const onSuccess = useCallback(() => {
+		const message = formatMessage(successMessageId, successMessageValues);
+		addNotification(message, "success");
+
+		if (successAction) {
+			successAction();
+		}
+		// addNotification causes issues in the deps
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [formatMessage, successAction, successMessageId, successMessageValues]);
+
+	const onError = useCallback(() => {
+		const message = formatMessage(errorMessageId, errorMessageValues);
+		addNotification(message, "error");
+
+		if (errorAction) {
+			errorAction();
+		}
+		// addNotification causes issues in the deps
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [errorAction, errorMessageId, errorMessageValues, formatMessage]);
+
+	const buildRequestState = useRequestState({
+		keys,
+		operation,
+		successAction: onSuccess,
+		errorAction: onError,
+	});
+
+	return buildRequestState;
+};
+
+export default useNotificationRequestState;

--- a/src/hooks/useNotificationRequestState.test.js
+++ b/src/hooks/useNotificationRequestState.test.js
@@ -1,20 +1,21 @@
 import Immutable from "immutable";
 import React from "react";
-import useRequestState from "./useRequestState";
+import useNotificationRequestState from "./useNotificationRequestState";
 import { extractMessages, TestWrapper } from "../utils/testUtils";
 import { requestStateOperations } from "../constants";
 import sharedMessages from "../sharedMessages";
 import sinon from "sinon";
 import { mount } from "enzyme";
 import { resetRequestState } from "../actions/requestState";
+import Snackbar from "@material-ui/core/Snackbar";
 
 const messages = extractMessages(sharedMessages);
 
-describe("useRequestState", () => {
+describe("useNotificationRequestState", () => {
 	let buildRequestState;
 
 	const TestComp = props => {
-		[buildRequestState] = useRequestState(props);
+		[buildRequestState] = useNotificationRequestState(props);
 		return <div>some content</div>;
 	};
 
@@ -50,7 +51,9 @@ describe("useRequestState", () => {
 				<TestComp
 					keys={["key1", "key2"]}
 					operation={requestStateOperations.delete}
+					successMessageId={sharedMessages.delete}
 					successAction={successSpy}
+					errorMessageId={sharedMessages.error}
 					errorAction={errorSpy}
 				/>
 			</TestWrapper>
@@ -71,7 +74,9 @@ describe("useRequestState", () => {
 				<TestComp
 					keys={["key1", "key2"]}
 					operation={requestStateOperations.delete}
+					successMessageId={sharedMessages.delete}
 					successAction={successSpy}
+					errorMessageId={sharedMessages.error}
 					errorAction={errorSpy}
 				/>
 			</TestWrapper>
@@ -97,19 +102,23 @@ describe("useRequestState", () => {
 				<TestComp
 					keys={["key1", "key2"]}
 					operation={requestStateOperations.delete}
+					successMessageId={sharedMessages.delete}
 					successAction={successSpy}
+					errorMessageId={sharedMessages.error}
 					errorAction={errorSpy}
 				/>
 			</TestWrapper>
 		);
 
-		mount(component);
+		const mountedComponent = mount(component);
+		const sb = mountedComponent.find(Snackbar);
 
 		const resetAction = resetRequestState(["key1", "key2"], requestStateOperations.delete);
 		expect(dispatchSpy, "to have a call satisfying", { args: [resetAction] });
 		expect(dispatchSpy, "to have a call satisfying", { args: [resetAction] });
 		expect(successSpy, "was called");
 		expect(errorSpy, "was not called");
+		expect(sb.prop("open"), "to equal", true);
 	});
 
 	it("success callback is not called when undefined", () => {
@@ -124,13 +133,21 @@ describe("useRequestState", () => {
 
 		const component = (
 			<TestWrapper provider={{ store }} intlProvider={{ messages }} stylesProvider>
-				<TestComp keys={["key1", "key2"]} operation={requestStateOperations.delete} errorAction={errorSpy} />
+				<TestComp
+					keys={["key1", "key2"]}
+					operation={requestStateOperations.delete}
+					successMessageId={sharedMessages.delete}
+					errorMessageId={sharedMessages.error}
+					errorAction={errorSpy}
+				/>
 			</TestWrapper>
 		);
 
-		mount(component);
+		const mountedComponent = mount(component);
+		const sb = mountedComponent.find(Snackbar);
 
 		expect(successSpy, "was not called");
+		expect(sb.prop("open"), "to equal", true);
 	});
 
 	it("dispatches the error actions", () => {
@@ -148,19 +165,23 @@ describe("useRequestState", () => {
 				<TestComp
 					keys={["key1", "key2"]}
 					operation={requestStateOperations.delete}
+					successMessageId={sharedMessages.delete}
 					successAction={successSpy}
+					errorMessageId={sharedMessages.error}
 					errorAction={errorSpy}
 				/>
 			</TestWrapper>
 		);
 
-		mount(component);
+		const mountedComponent = mount(component);
+		const sb = mountedComponent.find(Snackbar);
 
 		const resetAction = resetRequestState(["key1", "key2"], requestStateOperations.delete);
 		expect(dispatchSpy, "to have a call satisfying", { args: [resetAction] });
 		expect(dispatchSpy, "to have a call satisfying", { args: [resetAction] });
 		expect(successSpy, "was not called");
 		expect(errorSpy, "was called");
+		expect(sb.prop("open"), "to equal", true);
 	});
 
 	it("error action is not called when undefined", () => {
@@ -175,12 +196,20 @@ describe("useRequestState", () => {
 
 		const component = (
 			<TestWrapper provider={{ store }} intlProvider={{ messages }} stylesProvider>
-				<TestComp keys={["key1", "key2"]} operation={requestStateOperations.delete} successAction={successSpy} />
+				<TestComp
+					keys={["key1", "key2"]}
+					operation={requestStateOperations.delete}
+					successMessageId={sharedMessages.delete}
+					successAction={successSpy}
+					errorMessageId={sharedMessages.error}
+				/>
 			</TestWrapper>
 		);
 
-		mount(component);
+		const mountedComponent = mount(component);
+		const sb = mountedComponent.find(Snackbar);
 
 		expect(errorSpy, "was not called");
+		expect(sb.prop("open"), "to equal", true);
 	});
 });

--- a/src/hooks/useRequestState.js
+++ b/src/hooks/useRequestState.js
@@ -42,8 +42,6 @@ const useRequestState = ({ keys, operation, successAction, errorAction }) => {
 				errorAction();
 			}
 		}
-		// addNotification causes issues in the deps
-		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [dispatch, keys, operation, successAction, errorAction, inProgress, value, error]);
 
 	const buildRequestState = () => {

--- a/src/hooks/useRequestState.js
+++ b/src/hooks/useRequestState.js
@@ -1,0 +1,81 @@
+import { useIntl } from "react-intl";
+import useSelectorAndUnwrap from "./useSelectorAndUnwrap";
+import { getRequestStateInfo } from "../selectors/requestStates";
+import { useContext, useEffect, useRef } from "react";
+import { NotificationContext } from "../components/MaterialUI/Feedback/NotificationContext";
+import { useDispatch } from "react-redux";
+import { resetRequestState } from "../actions/requestState";
+
+/*
+    This hook is used to handle the notification message for deletes and updates.
+    We have a reducer scanning every request for a special payload (meta.requestState). If this
+    payload is detected we set some flags (inProgress, value, error) depending on the request type (_REQUEST, _SUCCESS, _FAILURE):
+        * inProgress: set to true while the request is executing
+        * value: set to false when starting the request and to true when the request has been executed successfully
+        * error: set to false when starting the request and to true when the request has not been executed successfully
+
+    This hook returns a method used to build a requestState object that is used in the meta data property of the dispatched action.
+    The expected format for the action is as follow:
+    {
+        type: 'some type',
+        ... // other properties
+        meta: {
+            requestState: {
+                keys: [],
+                operation: requestStateOperations.delete
+            }
+        }
+    }
+*/
+
+const useRequestState = ({ keys, operation, successMessageId, successAction, errorMessageId, errorAction }) => {
+	const { inProgress, value, error } = useSelectorAndUnwrap(getRequestStateInfo(operation, keys));
+	const { formatMessage } = useIntl();
+	const { addNotification } = useContext(NotificationContext);
+	const dispatch = useDispatch();
+
+	useEffect(() => {
+		if (value && !inProgress && !error) {
+			const message = formatMessage(successMessageId);
+
+			dispatch(resetRequestState(keys, operation));
+			addNotification(message, "success");
+			if (successAction) {
+				successAction();
+			}
+		} else if (!value && !inProgress && error) {
+			const message = formatMessage(errorMessageId);
+
+			dispatch(resetRequestState(keys, operation));
+			addNotification(message, "error");
+			if (errorAction) {
+				errorAction();
+			}
+		}
+		// addNotification causes issues in the deps
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [
+		dispatch,
+		keys,
+		operation,
+		successMessageId,
+		successAction,
+		errorMessageId,
+		errorAction,
+		formatMessage,
+		inProgress,
+		value,
+		error,
+	]);
+
+	const buildRequestState = () => {
+		return {
+			keys,
+			operation,
+		};
+	};
+
+	return [buildRequestState];
+};
+
+export default useRequestState;

--- a/src/hooks/useRequestState.js
+++ b/src/hooks/useRequestState.js
@@ -1,15 +1,13 @@
-import { useIntl } from "react-intl";
 import useSelectorAndUnwrap from "./useSelectorAndUnwrap";
 import { getRequestStateInfo } from "../selectors/requestStates";
-import { useContext, useEffect, useRef } from "react";
-import { NotificationContext } from "../components/MaterialUI/Feedback/NotificationContext";
+import { useEffect } from "react";
 import { useDispatch } from "react-redux";
 import { resetRequestState } from "../actions/requestState";
 
 /*
-    This hook is used to handle the notification message for deletes and updates.
-    We have a reducer scanning every request for a special payload (meta.requestState). If this
-    payload is detected we set some flags (inProgress, value, error) depending on the request type (_REQUEST, _SUCCESS, _FAILURE):
+    This hook is used to handle custom action after deletes and updates requests. We can add additional operation if required.
+    We have a reducer scanning every request for a special payload (meta.requestState).
+    If this payload is detected we set some flags (inProgress, value, error) depending on the request type (_REQUEST, _SUCCESS, _FAILURE):
         * inProgress: set to true while the request is executing
         * value: set to false when starting the request and to true when the request has been executed successfully
         * error: set to false when starting the request and to true when the request has not been executed successfully
@@ -28,45 +26,25 @@ import { resetRequestState } from "../actions/requestState";
     }
 */
 
-const useRequestState = ({ keys, operation, successMessageId, successAction, errorMessageId, errorAction }) => {
+const useRequestState = ({ keys, operation, successAction, errorAction }) => {
 	const { inProgress, value, error } = useSelectorAndUnwrap(getRequestStateInfo(operation, keys));
-	const { formatMessage } = useIntl();
-	const { addNotification } = useContext(NotificationContext);
 	const dispatch = useDispatch();
 
 	useEffect(() => {
 		if (value && !inProgress && !error) {
-			const message = formatMessage(successMessageId);
-
 			dispatch(resetRequestState(keys, operation));
-			addNotification(message, "success");
 			if (successAction) {
 				successAction();
 			}
 		} else if (!value && !inProgress && error) {
-			const message = formatMessage(errorMessageId);
-
 			dispatch(resetRequestState(keys, operation));
-			addNotification(message, "error");
 			if (errorAction) {
 				errorAction();
 			}
 		}
 		// addNotification causes issues in the deps
 		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [
-		dispatch,
-		keys,
-		operation,
-		successMessageId,
-		successAction,
-		errorMessageId,
-		errorAction,
-		formatMessage,
-		inProgress,
-		value,
-		error,
-	]);
+	}, [dispatch, keys, operation, successAction, errorAction, inProgress, value, error]);
 
 	const buildRequestState = () => {
 		return {

--- a/src/hooks/useRequestState.test.js
+++ b/src/hooks/useRequestState.test.js
@@ -1,0 +1,215 @@
+import Immutable from "immutable";
+import React from "react";
+import useRequestState from "./useRequestState";
+import { extractMessages, TestWrapper } from "../utils/testUtils";
+import { requestStateOperations } from "../constants";
+import sharedMessages from "../sharedMessages";
+import sinon from "sinon";
+import { mount } from "enzyme";
+import { resetRequestState } from "../actions/requestState";
+import Snackbar from "@material-ui/core/Snackbar";
+
+const messages = extractMessages(sharedMessages);
+
+describe("useRequestState", () => {
+	let buildRequestState;
+
+	const TestComp = props => {
+		[buildRequestState] = useRequestState(props);
+		return <div>some content</div>;
+	};
+
+	let state, store, successSpy, errorSpy, dispatchSpy;
+	beforeEach(() => {
+		state = Immutable.fromJS({
+			requestStates: {
+				deletes: {},
+				updates: {},
+			},
+		});
+
+		successSpy = sinon.spy().named("success");
+		errorSpy = sinon.spy().named("error");
+		dispatchSpy = sinon.spy().named("dispatch");
+
+		store = {
+			subscribe: () => {},
+			getState: () => state,
+			dispatch: dispatchSpy,
+		};
+	});
+
+	afterEach(() => {
+		successSpy.resetHistory();
+		errorSpy.resetHistory();
+		dispatchSpy.resetHistory();
+	});
+
+	it("buildRequestState builds the expected object", () => {
+		const component = (
+			<TestWrapper provider={{ store }} intlProvider={{ messages }} stylesProvider>
+				<TestComp
+					keys={["key1", "key2"]}
+					operation={requestStateOperations.delete}
+					successMessageId={sharedMessages.delete}
+					successAction={successSpy}
+					errorMessageId={sharedMessages.error}
+					errorAction={errorSpy}
+				/>
+			</TestWrapper>
+		);
+
+		mount(component);
+
+		const obj = buildRequestState();
+		expect(obj, "to equal", {
+			keys: ["key1", "key2"],
+			operation: requestStateOperations.delete,
+		});
+	});
+
+	it("does not dispatch anything for an empty state", () => {
+		const component = (
+			<TestWrapper provider={{ store }} intlProvider={{ messages }} stylesProvider>
+				<TestComp
+					keys={["key1", "key2"]}
+					operation={requestStateOperations.delete}
+					successMessageId={sharedMessages.delete}
+					successAction={successSpy}
+					errorMessageId={sharedMessages.error}
+					errorAction={errorSpy}
+				/>
+			</TestWrapper>
+		);
+
+		mount(component);
+
+		expect(dispatchSpy, "was not called");
+	});
+
+	it("dispatches the success actions", () => {
+		state = state.setIn(
+			["requestStates", "deletes", "key1", "key2", "state"],
+			Immutable.fromJS({
+				inProgress: false,
+				value: true,
+				error: false,
+			}),
+		);
+
+		const component = (
+			<TestWrapper provider={{ store }} intlProvider={{ messages }} stylesProvider>
+				<TestComp
+					keys={["key1", "key2"]}
+					operation={requestStateOperations.delete}
+					successMessageId={sharedMessages.delete}
+					successAction={successSpy}
+					errorMessageId={sharedMessages.error}
+					errorAction={errorSpy}
+				/>
+			</TestWrapper>
+		);
+
+		const mountedComponent = mount(component);
+		const sb = mountedComponent.find(Snackbar);
+
+		const resetAction = resetRequestState(["key1", "key2"], requestStateOperations.delete);
+		expect(dispatchSpy, "to have a call satisfying", { args: [resetAction] });
+		expect(dispatchSpy, "to have a call satisfying", { args: [resetAction] });
+		expect(successSpy, "was called");
+		expect(errorSpy, "was not called");
+		expect(sb.prop("open"), "to equal", true);
+	});
+
+	it("success callback is not called when undefined", () => {
+		state = state.setIn(
+			["requestStates", "deletes", "key1", "key2", "state"],
+			Immutable.fromJS({
+				inProgress: false,
+				value: true,
+				error: false,
+			}),
+		);
+
+		const component = (
+			<TestWrapper provider={{ store }} intlProvider={{ messages }} stylesProvider>
+				<TestComp
+					keys={["key1", "key2"]}
+					operation={requestStateOperations.delete}
+					successMessageId={sharedMessages.delete}
+					errorMessageId={sharedMessages.error}
+					errorAction={errorSpy}
+				/>
+			</TestWrapper>
+		);
+
+		const mountedComponent = mount(component);
+		const sb = mountedComponent.find(Snackbar);
+
+		expect(successSpy, "was not called");
+		expect(sb.prop("open"), "to equal", true);
+	});
+
+	it("dispatches the error actions", () => {
+		state = state.setIn(
+			["requestStates", "deletes", "key1", "key2", "state"],
+			Immutable.fromJS({
+				inProgress: false,
+				value: false,
+				error: true,
+			}),
+		);
+
+		const component = (
+			<TestWrapper provider={{ store }} intlProvider={{ messages }} stylesProvider>
+				<TestComp
+					keys={["key1", "key2"]}
+					operation={requestStateOperations.delete}
+					successMessageId={sharedMessages.delete}
+					successAction={successSpy}
+					errorMessageId={sharedMessages.error}
+					errorAction={errorSpy}
+				/>
+			</TestWrapper>
+		);
+
+		const mountedComponent = mount(component);
+		const sb = mountedComponent.find(Snackbar);
+
+		const resetAction = resetRequestState(["key1", "key2"], requestStateOperations.delete);
+		expect(dispatchSpy, "to have a call satisfying", { args: [resetAction] });
+		expect(dispatchSpy, "to have a call satisfying", { args: [resetAction] });
+		expect(successSpy, "was not called");
+		expect(errorSpy, "was called");
+		expect(sb.prop("open"), "to equal", true);
+	});
+
+	it("error action is not called when undefined", () => {
+		state = state.setIn(
+			["requestStates", "deletes", "key1", "key2", "state"],
+			Immutable.fromJS({
+				inProgress: false,
+				value: false,
+				error: true,
+			}),
+		);
+
+		const component = (
+			<TestWrapper provider={{ store }} intlProvider={{ messages }} stylesProvider>
+				<TestComp
+					keys={["key1", "key2"]}
+					operation={requestStateOperations.delete}
+					successMessageId={sharedMessages.delete}
+					successAction={successSpy}
+					errorMessageId={sharedMessages.error}
+				/>
+			</TestWrapper>
+		);
+
+		const mountedComponent = mount(component);
+		const sb = mountedComponent.find(Snackbar);
+
+		expect(errorSpy, "was not called");
+		expect(sb.prop("open"), "to equal", true);
+	});
+});

--- a/src/reducers/requestStates.js
+++ b/src/reducers/requestStates.js
@@ -1,6 +1,6 @@
 import Immutable from "immutable";
 import { castArray } from "lodash";
-import { requestStateOperationMap, requestStateOperations } from "../constants";
+import { requestStateOperationMap } from "../constants";
 
 const initialState = Immutable.fromJS({
 	deletes: Immutable.Map(),

--- a/src/reducers/requestStates.js
+++ b/src/reducers/requestStates.js
@@ -1,0 +1,92 @@
+import Immutable from "immutable";
+import { castArray } from "lodash";
+import { requestStateOperationMap, requestStateOperations } from "../constants";
+
+const initialState = Immutable.fromJS({
+	deletes: Immutable.Map(),
+	updates: Immutable.Map(),
+});
+
+const containsRequestStateData = action => {
+	return !!action?.meta?.requestState;
+};
+
+const getPathFromAction = action => {
+	const firstSegment = requestStateOperationMap[action.meta.requestState.operation];
+
+	if (!firstSegment) {
+		return null;
+	}
+
+	return [firstSegment, ...castArray(action.meta.requestState.keys)];
+};
+
+const requestStateReducer = (state = initialState, action) => {
+	if (!containsRequestStateData(action)) {
+		return state;
+	}
+
+	if (action.type.endsWith("_REQUEST")) {
+		const path = getPathFromAction(action);
+		if (path === null) {
+			return state;
+		}
+		return state.setIn(
+			[...path, "state"],
+			Immutable.fromJS({
+				inProgress: true,
+				value: false,
+				error: false,
+			}),
+		);
+	}
+	if (action.type.endsWith("_SUCCESS")) {
+		const path = getPathFromAction(action);
+		if (path === null) {
+			return state;
+		}
+		return state.setIn(
+			[...path, "state"],
+			Immutable.fromJS({
+				inProgress: false,
+				value: true,
+				error: false,
+			}),
+		);
+	}
+	if (action.type.endsWith("_FAILURE")) {
+		const path = getPathFromAction(action);
+		if (path === null) {
+			return state;
+		}
+		return state.setIn(
+			[...path, "state"],
+			Immutable.fromJS({
+				inProgress: false,
+				value: false,
+				error: true,
+			}),
+		);
+	}
+
+	switch (action.type) {
+		case "RESET_REQUEST_STATE": {
+			const path = getPathFromAction(action);
+			if (path === null) {
+				return state;
+			}
+			return state.setIn(
+				[...path, "state"],
+				Immutable.fromJS({
+					inProgress: false,
+					value: false,
+					error: false,
+				}),
+			);
+		}
+		default:
+			return state;
+	}
+};
+
+export default requestStateReducer;

--- a/src/reducers/requestStates.test.js
+++ b/src/reducers/requestStates.test.js
@@ -1,0 +1,376 @@
+import Immutable from "immutable";
+import reducer from "./requestStates";
+import { requestStateOperationMap, requestStateOperations } from "../constants";
+import { RESET_REQUEST_STATE } from "../actions/requestState";
+
+describe("Request reducer", () => {
+	it("behaves as a reducer should", () =>
+		expect(reducer, "to be a reducer with initial state", {
+			deletes: Immutable.Map(),
+			updates: Immutable.Map(),
+		}));
+
+	it("should do nothing for an unknown action with requestState", () => {
+		const oldState = Immutable.fromJS({
+			deletes: Immutable.Map(),
+			updates: Immutable.Map(),
+		});
+		const action = { type: "SOME_UNKNOWN_ACTION", meta: { requestState: {} } };
+		const newState = reducer(oldState, action);
+		expect(newState, "to be", oldState);
+	});
+
+	it("state should not be modified if the action does not have the correct state", () =>
+		expect(reducer, "to be a reducer with initial state", {
+			deletes: Immutable.Map(),
+			updates: Immutable.Map(),
+		}));
+
+	it("state should not be modified if the action does not have the correct state", () => {
+		const oldState = Immutable.fromJS({
+			deletes: Immutable.Map(),
+			updates: Immutable.Map(),
+		});
+		const action = { type: "TEST_THIS_REQUEST", meta: { requestState: null } };
+		const newState = reducer(oldState, action);
+		expect(newState, "to be", oldState);
+	});
+
+	it.each([
+		[requestStateOperations.delete, "REQUEST"],
+		[requestStateOperations.delete, "SUCCESS"],
+		[requestStateOperations.delete, "FAILURE"],
+		[requestStateOperations.update, "REQUEST"],
+		[requestStateOperations.update, "SUCCESS"],
+		[requestStateOperations.update, "FAILURE"],
+	])("%s %s should not modify the state if the operation is not supported", (operation, requestSuffix) => {
+		const oldState = Immutable.fromJS({
+			deletes: Immutable.Map(),
+			updates: Immutable.Map(),
+		});
+		const action = {
+			type: "TEST_THIS_" + requestSuffix,
+			meta: {
+				requestState: {
+					keys: ["key1", "key2"],
+					operation: "unsupported",
+				},
+			},
+		};
+		const newState = reducer(oldState, action);
+		expect(newState, "to be", oldState);
+	});
+
+	it.each([[requestStateOperations.delete], [requestStateOperations.update]])(
+		"%s operation REQUEST should initialize the state for the specified keys",
+		operation => {
+			const oldState = Immutable.fromJS({
+				deletes: Immutable.Map(),
+				updates: Immutable.Map(),
+			});
+			const action = {
+				type: "TEST_THIS_REQUEST",
+				meta: {
+					requestState: {
+						keys: ["key1", "key2"],
+						operation: operation,
+					},
+				},
+			};
+
+			const expectedState = oldState.set(
+				requestStateOperationMap[operation],
+				Immutable.fromJS({
+					key1: {
+						key2: {
+							state: {
+								inProgress: true,
+								value: false,
+								error: false,
+							},
+						},
+					},
+				}),
+			);
+
+			const newState = reducer(oldState, action);
+			expect(newState, "not to be", oldState).and("to equal", expectedState);
+		},
+	);
+
+	it.each([[requestStateOperations.delete], [requestStateOperations.update]])(
+		"%s operation SUCCESS should initialize the state for the specified keys",
+		operation => {
+			const oldState = Immutable.fromJS({
+				deletes: Immutable.Map(),
+				updates: Immutable.Map(),
+			});
+			const action = {
+				type: "TEST_THIS_SUCCESS",
+				meta: {
+					requestState: {
+						keys: ["key1", "key2"],
+						operation: operation,
+					},
+				},
+			};
+
+			const expectedState = oldState.set(
+				requestStateOperationMap[operation],
+				Immutable.fromJS({
+					key1: {
+						key2: {
+							state: {
+								inProgress: false,
+								value: true,
+								error: false,
+							},
+						},
+					},
+				}),
+			);
+
+			const newState = reducer(oldState, action);
+			expect(newState, "not to be", oldState).and("to equal", expectedState);
+		},
+	);
+
+	it.each([[requestStateOperations.delete], [requestStateOperations.update]])(
+		"%s operation FAILURE should initialize the state for the specified keys",
+		operation => {
+			const oldState = Immutable.fromJS({
+				deletes: Immutable.Map(),
+				updates: Immutable.Map(),
+			});
+			const action = {
+				type: "TEST_THIS_FAILURE",
+				meta: {
+					requestState: {
+						keys: ["key1", "key2"],
+						operation: operation,
+					},
+				},
+			};
+
+			const expectedState = oldState.set(
+				requestStateOperationMap[operation],
+				Immutable.fromJS({
+					key1: {
+						key2: {
+							state: {
+								inProgress: false,
+								value: false,
+								error: true,
+							},
+						},
+					},
+				}),
+			);
+
+			const newState = reducer(oldState, action);
+			expect(newState, "not to be", oldState).and("to equal", expectedState);
+		},
+	);
+
+	it.each([[requestStateOperations.delete], [requestStateOperations.update]])(
+		"%s operation should accept a string as key",
+		operation => {
+			const oldState = Immutable.fromJS({
+				deletes: Immutable.Map(),
+				updates: Immutable.Map(),
+			});
+			const action = {
+				type: "TEST_THIS_REQUEST",
+				meta: {
+					requestState: {
+						keys: "key1",
+						operation: operation,
+					},
+				},
+			};
+
+			const expectedState = oldState.set(
+				requestStateOperationMap[operation],
+				Immutable.fromJS({
+					key1: {
+						state: {
+							inProgress: true,
+							value: false,
+							error: false,
+						},
+					},
+				}),
+			);
+
+			const newState = reducer(oldState, action);
+			expect(newState, "not to be", oldState).and("to equal", expectedState);
+		},
+	);
+});
+
+describe("RESET_REQUEST_STATE", () => {
+	it("state should not be modified if the operation is not supported", () => {
+		const oldState = Immutable.fromJS({
+			deletes: Immutable.Map(),
+			updates: Immutable.Map(),
+		});
+		const action = {
+			type: RESET_REQUEST_STATE,
+			meta: {
+				requestState: {
+					keys: ["key1", "key2"],
+					operation: "unsupported",
+				},
+			},
+		};
+		const newState = reducer(oldState, action);
+		expect(newState, "to be", oldState);
+	});
+
+	it.each([[requestStateOperations.delete], [requestStateOperations.update]])(
+		"state is initialized when empty for %s operation",
+		operation => {
+			const oldState = Immutable.fromJS({
+				deletes: Immutable.Map(),
+				updates: Immutable.Map(),
+			});
+			const action = {
+				type: RESET_REQUEST_STATE,
+				meta: {
+					requestState: {
+						keys: ["key1", "key2"],
+						operation: operation,
+					},
+				},
+			};
+
+			const expectedState = oldState.set(
+				requestStateOperationMap[operation],
+				Immutable.fromJS({
+					key1: {
+						key2: {
+							state: {
+								inProgress: false,
+								value: false,
+								error: false,
+							},
+						},
+					},
+				}),
+			);
+
+			const newState = reducer(oldState, action);
+			expect(newState, "not to be", oldState).and("to equal", expectedState);
+		},
+	);
+
+	it.each([[requestStateOperations.delete], [requestStateOperations.update]])(
+		"state is initialized when not empty for %s operation",
+		operation => {
+			let oldState = Immutable.fromJS({
+				deletes: Immutable.Map(),
+				updates: Immutable.Map(),
+			});
+			const action = {
+				type: RESET_REQUEST_STATE,
+				meta: {
+					requestState: {
+						keys: ["key1", "key2"],
+						operation: operation,
+					},
+				},
+			};
+
+			oldState = oldState.set(
+				requestStateOperationMap[operation],
+				Immutable.fromJS({
+					key1: {
+						key2: {
+							state: {
+								inProgress: true,
+								value: true,
+								error: true,
+								anotherProp: true,
+							},
+						},
+					},
+				}),
+			);
+
+			const expectedState = oldState.set(
+				requestStateOperationMap[operation],
+				Immutable.fromJS({
+					key1: {
+						key2: {
+							state: {
+								inProgress: false,
+								value: false,
+								error: false,
+							},
+						},
+					},
+				}),
+			);
+
+			const newState = reducer(oldState, action);
+			expect(newState, "not to be", oldState).and("to equal", expectedState);
+		},
+	);
+
+	it.each([[requestStateOperations.delete], [requestStateOperations.update]])(
+		"other keys are not touched when state is initialized for %s operation",
+		operation => {
+			let oldState = Immutable.fromJS({
+				deletes: Immutable.Map({
+					key3: {
+						key4: {
+							state: {
+								inProgress: false,
+								value: true,
+								error: false,
+							},
+						},
+					},
+				}),
+				updates: Immutable.Map({
+					key3: {
+						key4: {
+							state: {
+								inProgress: false,
+								value: true,
+								error: false,
+							},
+						},
+					},
+				}),
+			});
+			const action = {
+				type: RESET_REQUEST_STATE,
+				meta: {
+					requestState: {
+						keys: ["key1", "key2"],
+						operation: operation,
+					},
+				},
+			};
+
+			const expectedState = oldState.mergeIn(
+				[requestStateOperationMap[operation]],
+				Immutable.fromJS({
+					key1: {
+						key2: {
+							state: {
+								inProgress: false,
+								value: false,
+								error: false,
+							},
+						},
+					},
+				}),
+			);
+
+			const newState = reducer(oldState, action);
+			expect(newState, "not to be", oldState).and("to equal", expectedState);
+		},
+	);
+});

--- a/src/selectors/requestStates.js
+++ b/src/selectors/requestStates.js
@@ -1,0 +1,12 @@
+import { createSelector } from "reselect";
+import { castArray } from "lodash";
+import { requestStateOperationMap } from "../constants";
+
+const requestStateData = state => state.get("requestStates");
+
+export const getRequestStateInfo = (operation, keys) => {
+	return createSelector(requestStateData, data => {
+		const firstSegment = requestStateOperationMap[operation];
+		return data.getIn([firstSegment, ...castArray(keys), "state"]) ?? {};
+	});
+};

--- a/src/selectors/requestStates.test.js
+++ b/src/selectors/requestStates.test.js
@@ -1,0 +1,83 @@
+import Immutable from "immutable";
+import { getRequestStateInfo } from "./requestStates";
+import { requestStateOperations } from "../constants";
+
+describe("getRequestStateInfo", () => {
+	let state;
+	beforeEach(() => {
+		state = Immutable.fromJS({
+			requestStates: {
+				deletes: {
+					key1: {
+						key2: {
+							state: {
+								inProgress: true,
+								value: false,
+								error: false,
+							},
+						},
+					},
+				},
+				updates: {
+					key3: {
+						state: {
+							inProgress: false,
+							value: true,
+							error: false,
+						},
+					},
+				},
+			},
+		});
+	});
+
+	it("gets the info of a requestState from state", () => {
+		const expected = Immutable.fromJS({
+			inProgress: true,
+			value: false,
+			error: false,
+		});
+
+		expect(
+			getRequestStateInfo,
+			"called with",
+			[requestStateOperations.delete, ["key1", "key2"]],
+			"called with",
+			[state],
+			"to equal",
+			expected,
+		);
+	});
+
+	it("gets empty info of an unknown requestState from state", () => {
+		const expected = {};
+
+		expect(
+			getRequestStateInfo,
+			"called with",
+			[requestStateOperations.delete, ["key1"]],
+			"called with",
+			[state],
+			"to equal",
+			expected,
+		);
+	});
+
+	it("gets the info of a requestState from state using a string instead of array for key", () => {
+		const expected = Immutable.fromJS({
+			inProgress: false,
+			value: true,
+			error: false,
+		});
+
+		expect(
+			getRequestStateInfo,
+			"called with",
+			[requestStateOperations.update, ["key3"]],
+			"called with",
+			[state],
+			"to equal",
+			expected,
+		);
+	});
+});


### PR DESCRIPTION
This hook is used to simplify the handling of user message based on the
outcome of a request. For example you can use it to display a
notification after deleting an entity.