### PR TITLE
Fix Scope TreeView alignment

### DIFF
--- a/src/components/MaterialUI/ScopeSelector/TreeItem.js
+++ b/src/components/MaterialUI/ScopeSelector/TreeItem.js
@@ -25,8 +25,9 @@ const useStyles = makeStyles(theme => ({
 		//   },
 		// }
 	},
-	globalIconContainer: {
+	rootIconContainer: {
 		marginRight: 0,
+		display: "none",
 	},
 	scopeLabel: {
 		position: "relative",
@@ -157,7 +158,7 @@ const TreeItem = ({ scope, rootId, onScopeSelect, children }) => {
 			onLabelClick={e => onLabelClickHandler(e)}
 			classes={{
 				group: classes.group,
-				iconContainer: classNames({ [classes.globalIconContainer]: isRootScope }),
+				iconContainer: classNames({ [classes.rootIconContainer]: isRootScope }),
 				content: classNames({ [classes.virtualScopeContent]: isVirtualScope }),
 				selected: classNames({ [classes.virtualScopeSelected]: isVirtualScope }),
 			}}

--- a/src/components/MaterialUI/muiThemes.js
+++ b/src/components/MaterialUI/muiThemes.js
@@ -979,9 +979,6 @@ const setThemeOverrides = theme => ({
 				left: theme.spacing(-2.1),
 				width: theme.spacing(2),
 			},
-			"&.Mui-expanded:before": {
-				width: theme.spacing(1.5),
-			},
 		},
 		label: {
 			...theme.label,
@@ -1026,6 +1023,21 @@ const setThemeOverrides = theme => ({
 			width: "auto",
 			"& svg": {
 				fontSize: "10px",
+			},
+			"&:before": {
+				content: `" "`,
+				position: "absolute",
+				height: theme.spacing(0.1),
+				width: theme.spacing(0.5),
+				left: theme.spacing(-0.5),
+				backgroundColor: theme.palette.grey.light,
+				top: theme.spacing(1.1),
+			},
+			"&:empty": {
+				display: "none",
+				"&:before": {
+					backgroundColor: "transparent",
+				},
 			},
 		},
 	},

--- a/src/components/MaterialUI/muiThemes.js
+++ b/src/components/MaterialUI/muiThemes.js
@@ -1034,9 +1034,11 @@ const setThemeOverrides = theme => ({
 				top: theme.spacing(1.1),
 			},
 			"&:empty": {
-				display: "none",
+				width: theme.spacing(1),
 				"&:before": {
 					backgroundColor: "transparent",
+					borderTop: `1px solid ${theme.palette.grey.borders}`,
+					width: theme.spacing(1.5),
 				},
 			},
 		},


### PR DESCRIPTION
+ Fix the scope icons alignment when there are no expand or collapse icon in front
+ Added a line to fill the gap

![Screen Shot 2021-08-25 at 8 12 47 AM](https://user-images.githubusercontent.com/44198946/130788579-9b5470be-4f28-42fe-9846-c9e5ae3fae53.png)

to

![Screen Shot 2021-08-25 at 8 14 02 AM](https://user-images.githubusercontent.com/44198946/130788602-ebfc47be-be0a-4c79-87c4-8ebbd6bceb00.png)
