### PR TITLE
Remove tooltip on Input base other than text

### DIFF
--- a/src/components/MaterialUI/DataDisplay/Table.js
+++ b/src/components/MaterialUI/DataDisplay/Table.js
@@ -64,21 +64,33 @@ export const useStyles = makeStyles(theme => ({
 	},
 	tableCell: {
 		padding: theme.spacing(2, 0.5),
+		"&:first-child": {
+			padding: theme.spacing(2, 0.5, 2, 2),
+		},
 	},
 	tableCellSelect: {
 		padding: theme.spacing(2, 0.5),
 		width: theme.spacing(3),
+		"&:first-child": {
+			padding: theme.spacing(2, 0.5, 2, 2),
+		},
 	},
 	headerCell: {
 		padding: theme.spacing(1, 0.5),
 		textAlign: "left",
 		fontWeight: theme.typography.fontWeightSemiBold,
+		"&:first-child": {
+			padding: theme.spacing(2, 0.5, 2, 2),
+		},
 	},
 	headerCellSelect: {
 		padding: theme.spacing(1, 0.5),
 		width: theme.spacing(3),
 		textAlign: "left",
 		fontWeight: theme.typography.fontWeightSemiBold,
+		"&:first-child": {
+			padding: theme.spacing(2, 0.5, 2, 2),
+		},
 	},
 	rowSelectCheckbox: {
 		padding: 0,

--- a/src/components/MaterialUI/Inputs/InputBase.js
+++ b/src/components/MaterialUI/Inputs/InputBase.js
@@ -100,6 +100,8 @@ const InputBase = ({ inputProps }) => {
 	const metadata = inputProps?.get(InputBaseProps.propNames.metadata);
 	const autoComplete = inputProps?.get(InputBaseProps.propNames.autoComplete);
 
+	const tooltipText = type === "text" ? value : "";
+
 	const onClick = item => {
 		// Fixes FireFox issue, where the input number buttons do not focus on input control,
 		// causing onBlur to never fire
@@ -141,7 +143,7 @@ const InputBase = ({ inputProps }) => {
 					startAdornment={startAdornment}
 					endAdornment={endAdornment}
 					rows={4}
-					title={value}
+					title={tooltipText}
 					autoComplete={autoComplete}
 				/>
 			</div>

--- a/src/components/MaterialUI/Inputs/InputBase.test.js
+++ b/src/components/MaterialUI/Inputs/InputBase.test.js
@@ -53,6 +53,44 @@ describe("InputBase Component", () => {
 		expect(mountedComponent.prop("inputProps").get(InputBaseProps.propNames.value), "to equal", aValue + aValue);
 	});
 
+	it("Renders InputBase component with title attribute for input of type text", () => {
+		const inputProps = new InputBaseProps();
+		const aLabel = "aLabel";
+		const aValue = "value";
+
+		inputProps.set(InputBaseProps.propNames.update, update);
+		inputProps.set(InputBaseProps.propNames.value, aValue);
+		inputProps.set(InputBaseProps.propNames.label, aLabel);
+		inputProps.set(InputBaseProps.propNames.type, "text");
+		inputProps.set(InputBaseProps.propNames.disabled, true);
+
+		const component = <InputBase inputProps={inputProps} />;
+
+		const mountedComponent = mount(component);
+		const expected = <InputBaseMUI value={aValue} title={aValue} />;
+
+		expect(mountedComponent.containsMatchingElement(expected), "to be truthy");
+	});
+
+	it("Renders InputBase component with title attribute for input types other than text", () => {
+		const inputProps = new InputBaseProps();
+		const aLabel = "aLabel";
+		const aValue = "value";
+
+		inputProps.set(InputBaseProps.propNames.update, update);
+		inputProps.set(InputBaseProps.propNames.value, aValue);
+		inputProps.set(InputBaseProps.propNames.label, aLabel);
+		inputProps.set(InputBaseProps.propNames.type, "number");
+		inputProps.set(InputBaseProps.propNames.disabled, true);
+
+		const component = <InputBase inputProps={inputProps} />;
+
+		const mountedComponent = mount(component);
+		const expected = <InputBaseMUI value={aValue} title="" />;
+
+		expect(mountedComponent.containsMatchingElement(expected), "to be truthy");
+	});
+
 	it("Renders InputBase component without labels", () => {
 		const inputProps = new InputBaseProps();
 		const aValue = "value";


### PR DESCRIPTION
[AB#52079](https://dev.azure.com/orckestra001/da965986-c85b-43be-9915-219568b000e5/_workitems/edit/52079)
Removed the tooltip text when an input is not of type "text"
Fixed table padding for the first element in the row