### PR TITLE
Rename object parameter to its expected value "left"

### DIFF
--- a/src/components/MaterialUI/DataDisplay/SelectionList.js
+++ b/src/components/MaterialUI/DataDisplay/SelectionList.js
@@ -54,7 +54,7 @@ const formatOnChange = (data, ids) => {
 	const selectedItems = data.filter(dataItem => ids.includes(dataItem.id));
 
 	return {
-		selectedItems: [...selectedItems],
+		left: [...selectedItems],
 	};
 };
 

--- a/src/components/MaterialUI/DataDisplay/SelectionList.test.js
+++ b/src/components/MaterialUI/DataDisplay/SelectionList.test.js
@@ -179,7 +179,7 @@ describe("SelectionList", () => {
 		let item = mountedComponent.find(ListItem).at(0);
 		item.invoke("onClick")();
 
-		expect(onChange.args[2][0], "to equal", { selectedItems: [list[0]] });
+		expect(onChange.args[2][0], "to equal", { left: [list[0]] });
 	});
 
 	it("Calls onChange with defaultSelection", () => {
@@ -196,7 +196,7 @@ describe("SelectionList", () => {
 
 		mount(component);
 
-		expect(onChange.args[1][0], "to equal", { selectedItems: [data[1]] });
+		expect(onChange.args[1][0], "to equal", { left: [data[1]] });
 	});
 
 	it("handle scrolling event", () => {


### PR DESCRIPTION
 #55248

Based on TransferList.js, the expected parameter name for the list on the left should be "left" 