### PR TITLE
Hotfixes/1.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "orc-shared",
-	"version": "1.1.0-dev.48",
+	"version": "1.1.0-pre.0",
 	"description": "Shared code for Orckestra applications",
 	"main": "./src/index.js",
 	"exports": {

--- a/src/selectors/metadata.js
+++ b/src/selectors/metadata.js
@@ -157,7 +157,8 @@ const definitionEntityAttributes = memoize((moduleName, entityName) =>
 	),
 );
 
-const filterIsBuiltInAttributes = isBuiltIn => attributes => attributes.filter(a => a.get("isBuiltIn") === isBuiltIn);
+const filterIsBuiltInAttributes = isBuiltIn => attributes =>
+	attributes.filter(a => a.get("isBuiltIn") === isBuiltIn).sortBy(x => x.get("displayOrder"));
 
 export const definitionEntityCustomAttributesSelector = memoize((moduleName, entityName) =>
 	createSelector(definitionEntityAttributes(moduleName, entityName), filterIsBuiltInAttributes(false)),
@@ -204,11 +205,15 @@ export const groupedCustomAttributesDefinitionSelector = memoize((moduleName, en
 					})
 						.set(
 							"baseAttributes",
-							group.filter(i => i.get("dataType") !== attributeDataType.entityReference),
+							group
+								.filter(i => i.get("dataType") !== attributeDataType.entityReference)
+								.sortBy(x => x.get("displayOrder")),
 						)
 						.set(
 							"profileAttributes",
-							group.filter(i => i.get("dataType") === attributeDataType.entityReference),
+							group
+								.filter(i => i.get("dataType") === attributeDataType.entityReference)
+								.sortBy(x => x.get("displayOrder")),
 						);
 				})
 				.sortBy(x => x.get("displayOrder")),
@@ -220,8 +225,12 @@ export const customAttributesDefinitionSelector = memoize((moduleName, profileEn
 		mappedDefinitionEntity(moduleName, profileEntityName),
 		customAttributesSelector(moduleName, profileEntityName),
 		(definition, attributes) => {
-			const profileAttributes = attributes?.filter(a => a.get("dataType") === attributeDataType.entityReference);
-			const baseAttributes = attributes?.filter(a => a.get("dataType") !== attributeDataType.entityReference);
+			const profileAttributes = attributes
+				?.filter(a => a.get("dataType") === attributeDataType.entityReference)
+				.sortBy(x => x.get("displayOrder"));
+			const baseAttributes = attributes
+				?.filter(a => a.get("dataType") !== attributeDataType.entityReference)
+				.sortBy(x => x.get("displayOrder"));
 			return definition.set("baseAttributes", baseAttributes).set("profileAttributes", profileAttributes);
 		},
 	),

--- a/src/selectors/metadata.js
+++ b/src/selectors/metadata.js
@@ -46,8 +46,10 @@ export const namedLookupSelector = memoize((moduleName, lookupName) =>
 );
 
 export const namedLookupValuesSelector = memoize((moduleName, lookupName) =>
-	createSelector(namedLookupSelector(moduleName, lookupName), currentLocaleOrDefault, (statuses, locale) =>
-		(statuses.get("values") || Immutable.Map()).map(status => setTranslation(locale, status, "displayName")),
+	createSelector(namedLookupSelector(moduleName, lookupName), currentLocaleOrDefault, (lookup, locale) =>
+		(lookup.get("values") || Immutable.Map()).map(lookupValue =>
+			setTranslationWithFallbackField(locale, lookupValue, "name", "displayName"),
+		),
 	),
 );
 

--- a/src/selectors/metadata.test.js
+++ b/src/selectors/metadata.test.js
@@ -848,6 +848,143 @@ describe("definitions", () => {
 		description: "InnaCustom2",
 	};
 
+	let baseBuitInAttribute1 = {
+		maximum: 256,
+		dataType: "Text",
+		isRequired: false,
+		name: "Username",
+		displayOrder: 1,
+		isSearchable: true,
+		displayName: {
+			"en-CA": "User name",
+			"en-US": "User name",
+			"fr-CA": "User name",
+		},
+		minimum: 1,
+		multilingual: false,
+		isBuiltIn: true,
+		groupId: "Default",
+		allowMultipleValues: false,
+	};
+
+	let baseBuitInAttribute2 = {
+		maximum: 256,
+		dataType: "Text",
+		isRequired: false,
+		name: "Email",
+		displayOrder: 2,
+		isSearchable: true,
+		displayName: {
+			"en-CA": "Email",
+			"en-US": "Email",
+			"fr-CA": "Email",
+		},
+		minimum: 0,
+		multilingual: false,
+		isBuiltIn: true,
+		groupId: "Default",
+		allowMultipleValues: false,
+	};
+
+	let baseBuitInAttribute3 = {
+		maximum: 64,
+		dataType: "Text",
+		isRequired: false,
+		name: "LastName",
+		displayOrder: 3,
+		isSearchable: true,
+		displayName: {
+			"en-CA": "Last name",
+			"en-US": "Last name",
+			"fr-CA": "Last name",
+			"it-IT": "Cognome",
+		},
+		minimum: 0,
+		multilingual: false,
+		isBuiltIn: true,
+		groupId: "Default",
+		allowMultipleValues: false,
+	};
+
+	let baseBuitInAttribute4 = {
+		maximum: 64,
+		dataType: "Text",
+		isRequired: false,
+		name: "FirstName",
+		displayOrder: 4,
+		isSearchable: true,
+		displayName: {
+			"ar-JO": "",
+			"en-CA": "First Name",
+			"en-US": "First Name",
+			"es-ES": "",
+			"fr-CA": "First Name",
+			"it-IT": "Nome",
+		},
+		minimum: 0,
+		multilingual: false,
+		isBuiltIn: true,
+		groupId: "Default",
+		allowMultipleValues: false,
+	};
+
+	let baseCustomAttribute1 = {
+		maximum: 64,
+		dataType: "Text",
+		isRequired: false,
+		name: "BaseAttribute1",
+		displayOrder: 1,
+		isSearchable: true,
+		displayName: {
+			"en-CA": "Base Attribute1",
+			"en-US": "Base Attribute1",
+			"fr-CA": "Base Attribute1",
+		},
+		minimum: 0,
+		multilingual: false,
+		isBuiltIn: false,
+		groupId: "Default",
+		allowMultipleValues: false,
+	};
+
+	let baseCustomAttribute2 = {
+		maximum: 64,
+		dataType: "Text",
+		isRequired: false,
+		name: "BaseAttribute2",
+		displayOrder: 2,
+		isSearchable: true,
+		displayName: {
+			"en-CA": "Base Attribute 2",
+			"en-US": "Base Attribute 2",
+			"fr-CA": "Base Attribute 2",
+		},
+		minimum: 0,
+		multilingual: false,
+		isBuiltIn: false,
+		groupId: "Default",
+		allowMultipleValues: false,
+	};
+
+	let baseCustomAttribute3 = {
+		maximum: 64,
+		dataType: "Text",
+		isRequired: false,
+		name: "BaseAttribute3",
+		displayOrder: 3,
+		isSearchable: true,
+		displayName: {
+			"en-CA": "Base Attribute 3",
+			"en-US": "Base Attribute 3",
+			"fr-CA": "Base Attribute 3",
+		},
+		minimum: 0,
+		multilingual: false,
+		isBuiltIn: false,
+		groupId: "Default",
+		allowMultipleValues: false,
+	};
+
 	beforeEach(() => {
 		state = Immutable.fromJS({
 			locale: {
@@ -978,90 +1115,15 @@ describe("definitions", () => {
 							entityTypeName: "CUSTOMER",
 							isBuiltIn: true,
 							attributes: [
-								{
-									maximum: 256,
-									dataType: "Text",
-									isRequired: false,
-									name: "Username",
-									displayOrder: 0,
-									isSearchable: true,
-									displayName: {
-										"ar-JO": "",
-										"en-CA": "User name",
-										"en-US": "User name",
-										"es-ES": "",
-										"fr-CA": "User name",
-										"it-IT": "Nome utente",
-									},
-									minimum: 1,
-									multilingual: false,
-									isBuiltIn: true,
-									groupId: "Default",
-									allowMultipleValues: false,
-								},
-								{
-									maximum: 256,
-									dataType: "Text",
-									isRequired: false,
-									name: "Email",
-									displayOrder: 0,
-									isSearchable: true,
-									displayName: {
-										"ar-JO": "",
-										"en-CA": "Email",
-										"en-US": "Email",
-										"es-ES": "",
-										"fr-CA": "Email",
-										"it-IT": "Email",
-									},
-									minimum: 0,
-									multilingual: false,
-									isBuiltIn: true,
-									groupId: "Default",
-									allowMultipleValues: false,
-								},
+								baseBuitInAttribute1,
+								baseBuitInAttribute2,
 								customProfileAttribute1,
 								customProfileAttribute2,
-								{
-									maximum: 64,
-									dataType: "Text",
-									isRequired: false,
-									name: "LastName",
-									displayOrder: 0,
-									isSearchable: true,
-									displayName: {
-										"en-CA": "Last name",
-										"en-US": "Last name",
-										"fr-CA": "Last name",
-										"it-IT": "Cognome",
-									},
-									minimum: 0,
-									multilingual: false,
-									isBuiltIn: true,
-									groupId: "Default",
-									allowMultipleValues: false,
-								},
-								{
-									maximum: 64,
-									dataType: "Text",
-									isRequired: false,
-									name: "FirstName",
-									displayOrder: 0,
-									isSearchable: true,
-									displayName: {
-										"ar-JO": "",
-										"en-CA": "First Name",
-										"en-US": "First Name",
-										"es-ES": "",
-										"fr-CA": "First Name",
-										"it-IT": "Nome",
-									},
-									minimum: 0,
-									multilingual: false,
-									isBuiltIn: true,
-									groupId: "Default",
-									allowMultipleValues: false,
-								},
+								baseBuitInAttribute4,
+								baseBuitInAttribute3,
+								baseCustomAttribute1,
+								baseCustomAttribute3,
+								baseCustomAttribute2,
 							],
 							isSharedEntity: true,
 						},
@@ -1359,7 +1421,7 @@ describe("definitions", () => {
 			{},
 		));
 
-	it("will return correct custom profile attributes definition", () => {
+	it("will return correct custom profile attributes definition in correct order", () => {
 		const expectedGroup1 = customProfileAttribute1.groupId;
 		const expectedGroup2 = customProfileAttribute2.groupId;
 		const expectedItem1 = {
@@ -1371,11 +1433,26 @@ describe("definitions", () => {
 			...{ displayName: customProfileAttribute2.displayName["en-US"] },
 		};
 
+		const expectedBaseCustomWithOrder1 = {
+			...baseCustomAttribute1,
+			...{ displayName: baseCustomAttribute1.displayName["en-US"] },
+		};
+
+		const expectedBaseCustomWithOrder2 = {
+			...baseCustomAttribute2,
+			...{ displayName: baseCustomAttribute2.displayName["en-US"] },
+		};
+
+		const expectedBaseCustomWithOrder3 = {
+			...baseCustomAttribute3,
+			...{ displayName: baseCustomAttribute3.displayName["en-US"] },
+		};
+
 		const expected = Immutable.fromJS({
 			[expectedGroup1]: {
 				id: expectedGroup1,
 				name: "Default en-US",
-				baseAttributes: [],
+				baseAttributes: [expectedBaseCustomWithOrder1, expectedBaseCustomWithOrder2, expectedBaseCustomWithOrder3],
 				profileAttributes: [expectedItem1],
 			},
 			[expectedGroup2]: {
@@ -1397,90 +1474,12 @@ describe("definitions", () => {
 		);
 	});
 
-	it("will return correct full base customer definition attributes", () => {
+	it("will return correct full base (built in) customer definition attributes", () => {
 		const expected = Immutable.fromJS([
-			{
-				maximum: 256,
-				dataType: "Text",
-				isRequired: false,
-				name: "Username",
-				displayOrder: 0,
-				isSearchable: true,
-				displayName: {
-					"ar-JO": "",
-					"en-CA": "User name",
-					"en-US": "User name",
-					"es-ES": "",
-					"fr-CA": "User name",
-					"it-IT": "Nome utente",
-				},
-				minimum: 1,
-				multilingual: false,
-				isBuiltIn: true,
-				groupId: "Default",
-				allowMultipleValues: false,
-			},
-			{
-				maximum: 256,
-				dataType: "Text",
-				isRequired: false,
-				name: "Email",
-				displayOrder: 0,
-				isSearchable: true,
-				displayName: {
-					"ar-JO": "",
-					"en-CA": "Email",
-					"en-US": "Email",
-					"es-ES": "",
-					"fr-CA": "Email",
-					"it-IT": "Email",
-				},
-				minimum: 0,
-				multilingual: false,
-				isBuiltIn: true,
-				groupId: "Default",
-				allowMultipleValues: false,
-			},
-			{
-				maximum: 64,
-				dataType: "Text",
-				isRequired: false,
-				name: "LastName",
-				displayOrder: 0,
-				isSearchable: true,
-				displayName: {
-					"en-CA": "Last name",
-					"en-US": "Last name",
-					"fr-CA": "Last name",
-					"it-IT": "Cognome",
-				},
-				minimum: 0,
-				multilingual: false,
-				isBuiltIn: true,
-				groupId: "Default",
-				allowMultipleValues: false,
-			},
-			{
-				maximum: 64,
-				dataType: "Text",
-				isRequired: false,
-				name: "FirstName",
-				displayOrder: 0,
-				isSearchable: true,
-				displayName: {
-					"ar-JO": "",
-					"en-CA": "First Name",
-					"en-US": "First Name",
-					"es-ES": "",
-					"fr-CA": "First Name",
-					"it-IT": "Nome",
-				},
-				minimum: 0,
-				multilingual: false,
-				isBuiltIn: true,
-				groupId: "Default",
-				allowMultipleValues: false,
-			},
+			baseBuitInAttribute1,
+			baseBuitInAttribute2,
+			baseBuitInAttribute3,
+			baseBuitInAttribute4,
 		]);
 		expect(
 			definitionEntityBaseAttributesSelector,
@@ -1495,34 +1494,11 @@ describe("definitions", () => {
 
 	it("will return correct full custom customer definition attributes", () => {
 		const expected = Immutable.fromJS([
-			{
-				dataType: "EntityReference",
-				isRequired: false,
-				name: "InnaCustom1",
-				displayOrder: 0,
-				isSearchable: false,
-				displayName: { "en-CA": "attribute en-CA", "en-US": "attribute en-US", "fr-CA": "" },
-				referenceTypeName: "CustomProfile1",
-				multilingual: false,
-				isBuiltIn: false,
-				groupId: "Default",
-				allowMultipleValues: true,
-				description: "InnaCustomer",
-			},
-			{
-				dataType: "EntityReference",
-				isRequired: false,
-				name: "InnaCustom2",
-				displayOrder: 0,
-				isSearchable: false,
-				displayName: { "en-CA": "attribute en-CA", "en-US": "attribute en-UA", "fr-CA": "" },
-				referenceTypeName: "CustomProfile2",
-				multilingual: false,
-				isBuiltIn: false,
-				groupId: "CustomGroup",
-				allowMultipleValues: true,
-				description: "InnaCustom2",
-			},
+			customProfileAttribute1,
+			customProfileAttribute2,
+			baseCustomAttribute1,
+			baseCustomAttribute2,
+			baseCustomAttribute3,
 		]);
 		expect(
 			definitionEntityCustomAttributesSelector,
@@ -1535,64 +1511,30 @@ describe("definitions", () => {
 		);
 	});
 
-	it("will return correct customer attributes", () => {
+	it("will return correct customer base (build in) attributes in correct order", () => {
+		const locale = "en-US";
+		const expectedBaseBuitInAttribute1 = {
+			...baseBuitInAttribute1,
+			...{ displayName: baseBuitInAttribute1.displayName[locale] },
+		};
+		const expectedBaseBuitInAttribute2 = {
+			...baseBuitInAttribute2,
+			...{ displayName: baseBuitInAttribute2.displayName[locale] },
+		};
+		const expectedBaseBuitInAttribute3 = {
+			...baseBuitInAttribute3,
+			...{ displayName: baseBuitInAttribute3.displayName[locale] },
+		};
+		const expectedBaseBuitInAttribute4 = {
+			...baseBuitInAttribute4,
+			...{ displayName: baseBuitInAttribute4.displayName[locale] },
+		};
+
 		const expected = Immutable.fromJS([
-			{
-				maximum: 256,
-				dataType: "Text",
-				isRequired: false,
-				name: "Username",
-				displayOrder: 0,
-				isSearchable: true,
-				displayName: "User name",
-				minimum: 1,
-				multilingual: false,
-				isBuiltIn: true,
-				groupId: "Default",
-				allowMultipleValues: false,
-			},
-			{
-				maximum: 256,
-				dataType: "Text",
-				isRequired: false,
-				name: "Email",
-				displayOrder: 0,
-				isSearchable: true,
-				displayName: "Email",
-				minimum: 0,
-				multilingual: false,
-				isBuiltIn: true,
-				groupId: "Default",
-				allowMultipleValues: false,
-			},
-			{
-				maximum: 64,
-				dataType: "Text",
-				isRequired: false,
-				name: "LastName",
-				displayOrder: 0,
-				isSearchable: true,
-				displayName: "Last name",
-				minimum: 0,
-				multilingual: false,
-				isBuiltIn: true,
-				groupId: "Default",
-				allowMultipleValues: false,
-			},
-			{
-				maximum: 64,
-				dataType: "Text",
-				isRequired: false,
-				name: "FirstName",
-				displayOrder: 0,
-				isSearchable: true,
-				displayName: "First Name",
-				minimum: 0,
-				multilingual: false,
-				isBuiltIn: true,
-				groupId: "Default",
-				allowMultipleValues: false,
-			},
+			expectedBaseBuitInAttribute1,
+			expectedBaseBuitInAttribute2,
+			expectedBaseBuitInAttribute3,
+			expectedBaseBuitInAttribute4,
 		]);
 		expect(
 			baseAttributesSelector,
@@ -1606,41 +1548,37 @@ describe("definitions", () => {
 	});
 
 	it("will return correct customer attributes definition", () => {
+		const locale = "en-US";
+		const expectedProfileAttribute1 = {
+			...customProfileAttribute1,
+			...{ displayName: customProfileAttribute1.displayName[locale] },
+		};
+		const expectedProfileAttribute2 = {
+			...customProfileAttribute2,
+			...{ displayName: customProfileAttribute2.displayName[locale] },
+		};
+
+		const expectedBase1 = {
+			...baseCustomAttribute1,
+			...{ displayName: baseCustomAttribute1.displayName[locale] },
+		};
+
+		const expectedBase2 = {
+			...baseCustomAttribute2,
+			...{ displayName: baseCustomAttribute2.displayName[locale] },
+		};
+
+		const expectedBase3 = {
+			...baseCustomAttribute3,
+			...{ displayName: baseCustomAttribute3.displayName[locale] },
+		};
+
 		const expected = Immutable.fromJS({
 			displayName: "Customer",
 			entityTypeName: "CUSTOMER",
 			isBuiltIn: true,
-			baseAttributes: [],
-			profileAttributes: [
-				{
-					dataType: "EntityReference",
-					isRequired: false,
-					name: "InnaCustom1",
-					displayOrder: 0,
-					isSearchable: false,
-					displayName: "attribute en-US",
-					referenceTypeName: "CustomProfile1",
-					multilingual: false,
-					isBuiltIn: false,
-					groupId: "Default",
-					allowMultipleValues: true,
-					description: "InnaCustomer",
-				},
-				{
-					dataType: "EntityReference",
-					isRequired: false,
-					name: "InnaCustom2",
-					displayOrder: 0,
-					isSearchable: false,
-					displayName: "attribute en-UA",
-					referenceTypeName: "CustomProfile2",
-					multilingual: false,
-					isBuiltIn: false,
-					groupId: "CustomGroup",
-					allowMultipleValues: true,
-					description: "InnaCustom2",
-				},
-			],
+			baseAttributes: [expectedBase1, expectedBase2, expectedBase3],
+			profileAttributes: [expectedProfileAttribute1, expectedProfileAttribute2],
 			isSharedEntity: true,
 		});
 		expect(

--- a/src/utils/setTranslation.js
+++ b/src/utils/setTranslation.js
@@ -3,8 +3,23 @@ import { flatten } from "./flatten";
 /* Replaces a locale string structure with the string for the given locale. */
 const setTranslation = (locale, obj, ...field) => {
 	if (!obj || !obj.getIn(flatten([field]))) return obj;
+	let localeValue = obj.getIn(flatten([field, locale]));
+	if (!localeValue && locale.includes("-")) {
+		let fieldValue = obj.getIn(flatten([field]));
+		let fieldKeys = fieldValue.keys();
+		let language = locale.substring(0, locale.indexOf("-"));
+
+		for (let key of fieldKeys) {
+			if (key !== locale && key.startsWith(language)) {
+				localeValue = obj.getIn(flatten([field, key]));
+				if (localeValue) {
+					break;
+				}
+			}
+		}
+	}
 	const value =
-		obj.getIn(flatten([field, locale])) ||
+		localeValue ||
 		obj
 			.getIn(flatten([field]))
 			.filter(i => i)

--- a/src/utils/setTranslation.test.js
+++ b/src/utils/setTranslation.test.js
@@ -96,4 +96,28 @@ describe("setTranslation", () => {
 				hat: { name: "it-name" },
 			}),
 		));
+
+	it("returns first not empty match by language if language-culture not found", () =>
+		expect(
+			setTranslation,
+			"when called with",
+			[
+				"en-US",
+				Immutable.fromJS({
+					hat: {
+						name: {
+							"en-CA": "",
+							"fr-CA": "fr CA name",
+							"en-GB": "en GB name",
+							"it-IT": "it-name",
+						},
+					},
+				}),
+				["hat", "name"],
+			],
+			"to equal",
+			Immutable.fromJS({
+				hat: { name: "en GB name" },
+			}),
+		));
 });

--- a/src/utils/setTranslationWithFallback.js
+++ b/src/utils/setTranslationWithFallback.js
@@ -2,7 +2,24 @@ import { flatten } from "./flatten";
 
 export const setTranslationWithFallbackValue = (locale, obj, fallbackValue, ...field) => {
 	if (!obj) return obj;
-	const value = obj.getIn(flatten([field, locale])) || fallbackValue || "";
+	let localeValue = obj.getIn(flatten([field, locale]));
+	if (!localeValue && locale.includes("-")) {
+		let fieldValue = obj.getIn(flatten([field]));
+		if (fieldValue) {
+			let fieldKeys = fieldValue.keys();
+			let language = locale.substring(0, locale.indexOf("-"));
+
+			for (let key of fieldKeys) {
+				if (key !== locale && key.startsWith(language)) {
+					localeValue = obj.getIn(flatten([field, key]));
+					if (localeValue) {
+						break;
+					}
+				}
+			}
+		}
+	}
+	const value = localeValue || fallbackValue || "";
 	return obj.setIn(flatten([field]), value);
 };
 

--- a/src/utils/setTranslationWithFallback.test.js
+++ b/src/utils/setTranslationWithFallback.test.js
@@ -184,6 +184,24 @@ describe("setTranslationWithFallbackValue", () => {
 			}),
 		));
 
+	it("returns first not empty value matched by language when match by language-culture does not exist", () =>
+		expect(
+			setTranslationWithFallbackValue,
+			"when called with",
+			[
+				"en-US",
+				Immutable.fromJS({
+					hat: { name: { "en-GB": "", "en-CA": "en-CA Name" } },
+				}),
+				"fallbakValue",
+				["hat", "name"],
+			],
+			"to equal",
+			Immutable.fromJS({
+				hat: { name: "en-CA Name" },
+			}),
+		));
+
 	it("returns value fallback value  when match by language-culture and language does not exist", () =>
 		expect(
 			setTranslationWithFallbackValue,

--- a/src/utils/setTranslationWithFallback.test.js
+++ b/src/utils/setTranslationWithFallback.test.js
@@ -147,4 +147,94 @@ describe("setTranslationWithFallbackValue", () => {
 			"to equal",
 			null,
 		));
+
+	it("returns value matched by language-culture when exist", () =>
+		expect(
+			setTranslationWithFallbackValue,
+			"when called with",
+			[
+				"en-US",
+				Immutable.fromJS({
+					hat: { name: { "en-US": "en-US Name", "en-GB": "en-GB Name" } },
+				}),
+				"fallbakValue",
+				["hat", "name"],
+			],
+			"to equal",
+			Immutable.fromJS({
+				hat: { name: "en-US Name" },
+			}),
+		));
+
+	it("returns value matched by language when match by language-culture does not exist", () =>
+		expect(
+			setTranslationWithFallbackValue,
+			"when called with",
+			[
+				"en-US",
+				Immutable.fromJS({
+					hat: { name: { "en-GB": "en-GB Name" } },
+				}),
+				"fallbakValue",
+				["hat", "name"],
+			],
+			"to equal",
+			Immutable.fromJS({
+				hat: { name: "en-GB Name" },
+			}),
+		));
+
+	it("returns value fallback value  when match by language-culture and language does not exist", () =>
+		expect(
+			setTranslationWithFallbackValue,
+			"when called with",
+			[
+				"en-GB",
+				Immutable.fromJS({
+					hat: { name: { "fr-CA": "fr-CA Name" } },
+				}),
+				"fallbakValue",
+				["hat", "name"],
+			],
+			"to equal",
+			Immutable.fromJS({
+				hat: { name: "fallbakValue" },
+			}),
+		));
+
+	it("returns fallbak Value when field value is empty ", () =>
+		expect(
+			setTranslationWithFallbackValue,
+			"when called with",
+			[
+				"en-GB",
+				Immutable.fromJS({
+					hat: { name: {} },
+				}),
+				"fallbakValue",
+				["hat", "name"],
+			],
+			"to equal",
+			Immutable.fromJS({
+				hat: { name: "fallbakValue" },
+			}),
+		));
+
+	it("returns fallbakValue when field is undefined ", () =>
+		expect(
+			setTranslationWithFallbackValue,
+			"when called with",
+			[
+				"en-GB",
+				Immutable.fromJS({
+					hat: { name: {} },
+				}),
+				"fallbakValue",
+				["hat", "name2"],
+			],
+			"to equal",
+			Immutable.fromJS({
+				hat: { name: {}, name2: "fallbakValue" },
+			}),
+		));
 });


### PR DESCRIPTION
Main changes:
- add order by displayOrder for custom attributes ([AB#55950](https://dev.azure.com/orckestra001/da965986-c85b-43be-9915-219568b000e5/_workitems/edit/55950))
- change logic for setTranslation helper, so first we are looking by language-culture, then by language, then get first not empty
-  change logic for setTranslationWithFallbackValue helper, so first we are looking by language-culture, then by language, then use fallback value

Fix bugs:
[AB#55929](https://dev.azure.com/orckestra001/da965986-c85b-43be-9915-219568b000e5/_workitems/edit/55929)
[AB#55942](https://dev.azure.com/orckestra001/da965986-c85b-43be-9915-219568b000e5/_workitems/edit/55942)
[AB#55950](https://dev.azure.com/orckestra001/da965986-c85b-43be-9915-219568b000e5/_workitems/edit/55950)
