### PR TITLE
Use browser language to display date, time, first day of week, etc.

### DIFF
--- a/src/components/Culture.js
+++ b/src/components/Culture.js
@@ -1,0 +1,25 @@
+import React from "react";
+import { useMemo } from "react";
+import { useSelector } from "react-redux";
+import { currentLocaleOrDefault } from "../selectors/locale";
+import { registerLocale, setDefaultLocale } from "react-datepicker";
+import * as date_fns_locale from "date-fns/locale";
+import { findCorrespondingLocale } from "../utils/localizationHelper";
+
+const Culture = () => {
+	const locale = useSelector(currentLocaleOrDefault);
+	const language = navigator.language ?? locale;
+
+	useMemo(() => {
+		const fnsLocale = findCorrespondingLocale(date_fns_locale, language);
+
+		if (fnsLocale != null) {
+			registerLocale(language, fnsLocale);
+			setDefaultLocale(language);
+		}
+	}, [language]);
+
+	return <React.Fragment />;
+};
+
+export default Culture;

--- a/src/components/Culture.test.js
+++ b/src/components/Culture.test.js
@@ -1,0 +1,86 @@
+import React from "react";
+import Immutable from "immutable";
+import { Provider } from "react-redux";
+import { getDefaultLocale } from "react-datepicker";
+import Culture from "./Culture";
+
+describe("Culture", () => {
+	let state, store, languageGetter;
+
+	beforeEach(() => {
+		languageGetter = jest.spyOn(window.navigator, "language", "get");
+
+		state = Immutable.fromJS({
+			requests: {},
+			settings: {
+				defaultScope: "aDefaultScope",
+			},
+			locale: {
+				supportedLocales: [
+					{ language: "English", cultureIso: "en" },
+					{ language: "Français", cultureIso: "fr" },
+				],
+			},
+		});
+		store = {
+			subscribe: () => {},
+			getState: () => state,
+			dispatch: () => {},
+		};
+	});
+
+	afterEach(() => {
+		languageGetter.mockReset();
+		jest.clearAllMocks();
+	});
+
+	it("shows the wrapped component if authenticated and default scope is known", () => {
+		languageGetter.mockReturnValue(null);
+
+		const component = (
+			<Provider store={store}>
+				<Culture />
+			</Provider>
+		);
+
+		expect(component, "when mounted", "to satisfy", null);
+
+		expect(getDefaultLocale(), "to be", undefined); // Default behavior for react-datepicker
+	});
+
+	it("shows the wrapped component if authenticated and default scope is known 222", () => {
+		state = state.setIn(["locale", "supportedLocales"], [{ language: "English", cultureIso: "en" }]);
+		languageGetter.mockReturnValue("en-GB");
+
+		const component = (
+			<Provider store={store}>
+				<Culture />
+			</Provider>
+		);
+
+		expect(component, "when mounted", "to satisfy", null);
+
+		expect(getDefaultLocale(), "to equal", "en-GB");
+	});
+
+	it("shows the wrapped component if authenticated and default scope is known 333", () => {
+		state = state.setIn(
+			["locale", "supportedLocales"],
+			[
+				{ language: "French", cultureIso: "fr" },
+				{ language: "EnglishMy", cultureIso: "enMy" },
+			],
+		);
+		languageGetter.mockReturnValue("fr-FR");
+
+		const component = (
+			<Provider store={store}>
+				<Culture />
+			</Provider>
+		);
+
+		expect(component, "when mounted", "to satisfy", null);
+
+		expect(getDefaultLocale(), "to equal", "fr-FR");
+	});
+});

--- a/src/components/I18n.js
+++ b/src/components/I18n.js
@@ -6,10 +6,12 @@ import { currentLocaleOrDefault } from "../selectors/locale";
 const I18n = props => {
 	const locale = useSelector(currentLocaleOrDefault);
 	const messages = require("translations/" + locale + ".json");
+	const language = navigator.language ?? locale;
+
 	return (
 		<IntlProvider
-			key={locale} // TODO: Remove this when react-intl suports new React context API
-			locale={locale}
+			key={language} // TODO: Remove this when react-intl suports new React context API
+			locale={language}
 			messages={messages}
 			{...props}
 		/>

--- a/src/components/I18n.test.js
+++ b/src/components/I18n.test.js
@@ -9,10 +9,13 @@ import I18n from "./I18n";
 jest.mock("translations/en-US.json", () => ({
 	WORD: "Word",
 }));
+jest.mock("translations/fr-CA.json", () => ({
+	WORD: "Mots",
+}));
 
 describe("I18n", () => {
 	spyOnConsole();
-	let store, state;
+	let store, state, languageGetter;
 	beforeEach(() => {
 		state = Immutable.fromJS({
 			locale: {
@@ -25,9 +28,16 @@ describe("I18n", () => {
 			dispatch: () => {},
 			getState: () => state,
 		};
+
+		languageGetter = jest.spyOn(window.navigator, "language", "get");
 	});
 
-	it("renders a react-intl IntlProvider with locale data provided", () =>
+	afterEach(() => {
+		languageGetter.mockReset();
+	});
+
+	it("renders a react-intl IntlProvider with locale data provided", () => {
+		languageGetter.mockReturnValue(null);
 		expect(
 			<Provider store={store}>
 				<MemoryRouter>
@@ -39,5 +49,24 @@ describe("I18n", () => {
 			"when mounted",
 			"to satisfy",
 			"Word",
-		).then(() => expect(console.error, "was not called")));
+		).then(() => expect(console.error, "was not called"));
+	});
+
+	it("renders a react-intl IntlProvider with navigator language provided", () => {
+		languageGetter.mockReturnValue("fr-CA");
+		state = state.setIn(["locale", "locale"], "fr-CA");
+
+		expect(
+			<Provider store={store}>
+				<MemoryRouter>
+					<I18n>
+						<FormattedMessage id="WORD" defaultMessage="Failure" />
+					</I18n>
+				</MemoryRouter>
+			</Provider>,
+			"when mounted",
+			"to satisfy",
+			"Mots",
+		).then(() => expect(console.error, "was not called"));
+	});
 });

--- a/src/components/MaterialUI/Inputs/DatePicker.js
+++ b/src/components/MaterialUI/Inputs/DatePicker.js
@@ -5,12 +5,6 @@ import DatePicker from "react-datepicker";
 import "react-datepicker/dist/react-datepicker.css";
 import TimePicker from "./TimePicker";
 import { makeStyles } from "@material-ui/core/styles";
-import { useIntl } from "react-intl";
-import { registerLocale } from "react-datepicker";
-import { frCA, enUS, it } from "date-fns/locale";
-registerLocale("fr-CA", frCA);
-registerLocale("en-US", enUS);
-registerLocale("it-IT", it);
 
 const useStyles = makeStyles(theme => ({
 	container: {
@@ -111,21 +105,13 @@ const useStyles = makeStyles(theme => ({
 	},
 }));
 
-const AMPMLocales = ["en-US", "en-CA"];
-
-export const createFormat = (useDate, useTime, selectedLocale) => {
+export const createFormat = (useDate, useTime) => {
 	if (useDate && !useTime) {
 		return "P";
 	} else if (useTime && !useDate) {
-		if (AMPMLocales.includes(selectedLocale)) {
-			return "p";
-		}
-		return "HH:mm";
+		return "p";
 	} else {
-		if (AMPMLocales.includes(selectedLocale)) {
-			return "P p";
-		}
-		return "P HH:mm";
+		return "P p";
 	}
 };
 
@@ -144,7 +130,6 @@ const WrappedDatePicker = ({
 	error,
 	...props
 }) => {
-	const { locale } = useIntl();
 	const classes = useStyles({ readOnly });
 	const startDate = value ? new Date(value) : null;
 	const disabledCls = classNames({ [classes.disabled]: props.disabled });
@@ -161,24 +146,17 @@ const WrappedDatePicker = ({
 				<div className={classes.datePickerContainer}>
 					<DatePicker
 						{...props}
-						dateFormat={dateFormat || createFormat(useDate, useTime, locale)}
+						dateFormat={dateFormat || createFormat(useDate, useTime)}
 						selected={startDate}
 						onChange={date => updateDate(date, metadata)}
 						showTimeInput={useTime ?? false}
 						useTime={useTime ?? false}
 						customTimeInput={
-							useTime ? (
-								<TimePicker
-									showTimeZone={showTimeZone}
-									showAMPM={AMPMLocales.includes(locale)}
-									requestedTimeZone={timePickerTimeZone}
-								/>
-							) : null
+							useTime ? <TimePicker showTimeZone={showTimeZone} requestedTimeZone={timePickerTimeZone} /> : null
 						}
 						timeInputLabel={timeInputLabel ?? ""}
 						readOnly={readOnly}
 						showTimeSelectOnly={showTimeSelectOnly}
-						locale={locale}
 					/>
 				</div>
 				{!readOnly ? (

--- a/src/components/MaterialUI/Inputs/DatePicker.test.js
+++ b/src/components/MaterialUI/Inputs/DatePicker.test.js
@@ -314,43 +314,15 @@ describe("DatePicker", () => {
 });
 
 describe("createFormat", () => {
-	it("Retrieves proper format if locale is in AMPMLocales list for date and time", () => {
-		const locale1 = "en-CA";
-		const locale2 = "en-US";
-
-		expect(createFormat(true, true, locale1), "to equal", "P p");
-		expect(createFormat(true, true, locale2), "to equal", "P p");
+	it("Retrieves proper format for date and time", () => {
+		expect(createFormat(true, true), "to equal", "P p");
 	});
 
-	it("Retrieves proper format if locale is in AMPMLocales list for date", () => {
-		const locale1 = "en-CA";
-		const locale2 = "en-US";
-
-		expect(createFormat(true, false, locale1), "to equal", "P");
-		expect(createFormat(true, false, locale2), "to equal", "P");
+	it("Retrieves proper format for date only", () => {
+		expect(createFormat(true, false), "to equal", "P");
 	});
 
-	it("Retrieves proper format if locale is in AMPMLocales list for time", () => {
-		const locale1 = "en-CA";
-		const locale2 = "en-US";
-
-		expect(createFormat(false, true, locale1), "to equal", "p");
-		expect(createFormat(false, true, locale2), "to equal", "p");
-	});
-
-	it("Retrieves proper format if locale is not in AMPMLocales list for date and time", () => {
-		expect(createFormat(true, true, "fr-CA"), "to equal", "P HH:mm");
-	});
-
-	it("Retrieves proper format if locale is not in AMPMLocales list for date", () => {
-		expect(createFormat(true, false, "fr-CA"), "to equal", "P");
-	});
-
-	it("Retrieves proper format if locale is not in AMPMLocales list for time", () => {
-		expect(createFormat(false, true, "fr-CA"), "to equal", "HH:mm");
-	});
-
-	it("Retrieves date and time in 24h system by default", () => {
-		expect(createFormat(), "to equal", "P HH:mm");
+	it("Retrieves proper format for date only", () => {
+		expect(createFormat(false, true), "to equal", "p");
 	});
 });

--- a/src/components/Provision.js
+++ b/src/components/Provision.js
@@ -10,6 +10,7 @@ import DevPages from "./DevPages";
 import Head from "./Head";
 import I18n from "./I18n";
 import InternetExplorerWarningMessage from "./InternetExplorerWarningMessage";
+import Culture from "./Culture";
 
 const GlobalStyle = createGlobalStyle`
 	html {
@@ -41,6 +42,7 @@ const Provision = ({ store, theme = {}, muiTheme, children }) => {
 					<MuiThemeProvider theme={muiTheme}>
 						<React.Fragment>
 							<Head />
+							<Culture />
 							<GlobalStyle />
 							<Authenticate>
 								<React.Fragment>

--- a/src/utils/localizationHelper.js
+++ b/src/utils/localizationHelper.js
@@ -22,7 +22,19 @@ export function getNotLocalizedString(value) {
 	return value && `[${value}]`;
 }
 
+export function findCorrespondingLocale(locales, language) {
+	return (
+		locales[language] ??
+		locales[language.replace(/-/g, "")] ??
+		locales[language.toLowerCase()] ??
+		locales[language.toLowerCase().replace(/-/g, "")] ??
+		locales[language.substring(0, 2).toLowerCase()] ??
+		null
+	);
+}
+
 export default {
 	getLocalization,
 	getNotLocalizedString,
+	findCorrespondingLocale,
 };

--- a/src/utils/localizationHelper.test.js
+++ b/src/utils/localizationHelper.test.js
@@ -76,3 +76,67 @@ describe("<localizationHelper.getLocalization>", () => {
 		expect(localizationHelper.getLocalization(defaultLocalizations, "it", "fallback"), "to equal", fallbackValue);
 	});
 });
+
+describe("findCorrespondingLocale", () => {
+	const locales = {
+		fr: "FR",
+		enGB: "GB",
+		enNZ: "NZ",
+		"en-in": "IN",
+		enau: "AU",
+		"en-IE": "IE",
+		frCa: "CA",
+	};
+
+	it("findCorrespondingLocale should return null for en-US", () => {
+		expect(localizationHelper.findCorrespondingLocale(locales, "en-US"), "to equal", null);
+	});
+
+	it("findCorrespondingLocale should return FR for fr-FR", () => {
+		expect(localizationHelper.findCorrespondingLocale(locales, "fr-FR"), "to equal", "FR");
+	});
+
+	it("findCorrespondingLocale should return FR for fr-fr", () => {
+		expect(localizationHelper.findCorrespondingLocale(locales, "fr-fr"), "to equal", "FR");
+	});
+
+	it("findCorrespondingLocale should return FR for frFR", () => {
+		expect(localizationHelper.findCorrespondingLocale(locales, "frFR"), "to equal", "FR");
+	});
+
+	it("findCorrespondingLocale should return FR for frfr", () => {
+		expect(localizationHelper.findCorrespondingLocale(locales, "frfr"), "to equal", "FR");
+	});
+
+	it("findCorrespondingLocale should return IE for en-IE", () => {
+		expect(localizationHelper.findCorrespondingLocale(locales, "en-IE"), "to equal", "IE");
+	});
+
+	it("findCorrespondingLocale should return GB for en-GB", () => {
+		expect(localizationHelper.findCorrespondingLocale(locales, "en-GB"), "to equal", "GB");
+	});
+
+	it("findCorrespondingLocale should return GB for en-NZ", () => {
+		expect(localizationHelper.findCorrespondingLocale(locales, "en-NZ"), "to equal", "NZ");
+	});
+
+	it("findCorrespondingLocale should return AU for en-AU", () => {
+		expect(localizationHelper.findCorrespondingLocale(locales, "en-AU"), "to equal", "AU");
+	});
+
+	it("findCorrespondingLocale should return AU for en-au", () => {
+		expect(localizationHelper.findCorrespondingLocale(locales, "en-au"), "to equal", "AU");
+	});
+
+	it("findCorrespondingLocale should return AU for enAU", () => {
+		expect(localizationHelper.findCorrespondingLocale(locales, "enAU"), "to equal", "AU");
+	});
+
+	it("findCorrespondingLocale should return IN for en-IN", () => {
+		expect(localizationHelper.findCorrespondingLocale(locales, "en-IN"), "to equal", "IN");
+	});
+
+	it("findCorrespondingLocale should return CA for frCa", () => {
+		expect(localizationHelper.findCorrespondingLocale(locales, "frCa"), "to equal", "CA");
+	});
+});


### PR DESCRIPTION
Use browser language to display date, time, first day of week, etc.

Texts translation will still be used on the user preferences.

Story: [AB#56888](https://dev.azure.com/orckestra001/da965986-c85b-43be-9915-219568b000e5/_workitems/edit/56888)