### PR TITLE
Add timeout delay to prevent search Find call

### DIFF
--- a/src/components/MaterialUI/Inputs/InputBase.js
+++ b/src/components/MaterialUI/Inputs/InputBase.js
@@ -99,6 +99,7 @@ const InputBase = ({ inputProps }) => {
 	const endAdornment = inputProps?.get(InputBaseProps.propNames.endAdornment);
 	const metadata = inputProps?.get(InputBaseProps.propNames.metadata);
 	const autoComplete = inputProps?.get(InputBaseProps.propNames.autoComplete);
+	const timeoutDelay = inputProps?.get(InputBaseProps.propNames.timeoutDelay) || 100;
 
 	const tooltipText = type === "text" ? value : "";
 
@@ -128,7 +129,7 @@ const InputBase = ({ inputProps }) => {
 
 	React.useEffect(() => {
 		if (inputText !== value && inputText != null && window.bypassDebounce !== true) {
-			const timeOutId = setTimeout(() => update(inputText, metadata), 100);
+			const timeOutId = setTimeout(() => update(inputText, metadata), timeoutDelay);
 			return () => clearTimeout(timeOutId);
 		}
 		// eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/components/MaterialUI/Inputs/InputBaseProps.js
+++ b/src/components/MaterialUI/Inputs/InputBaseProps.js
@@ -17,6 +17,7 @@ class InputBaseProps extends ComponentProps {
 		endAdornment: "endAdornment",
 		metadata: "metadata",
 		autoComplete: "autoComplete",
+		timeoutDelay: "timeoutDelay",
 	};
 
 	static ruleNames = {
@@ -41,6 +42,7 @@ class InputBaseProps extends ComponentProps {
 		this.componentProps.set(this.constructor.propNames.endAdornment, null);
 		this.componentProps.set(this.constructor.propNames.metadata, null);
 		this.componentProps.set(this.constructor.propNames.autoComplete, null);
+		this.componentProps.set(this.constructor.propNames.timeoutDelay, null);
 
 		this.componentClasses.set(this.constructor.ruleNames.input, null);
 		this.componentClasses.set(this.constructor.ruleNames.errorText, null);

--- a/src/components/MaterialUI/Inputs/InputBaseProps.test.js
+++ b/src/components/MaterialUI/Inputs/InputBaseProps.test.js
@@ -18,6 +18,7 @@ describe("InputBase Props", () => {
 			"endAdornment",
 			"metadata",
 			"autoComplete",
+			"timeoutDelay",
 		];
 
 		expect(InputBaseProps.propNames, "to have keys", propNames);
@@ -40,6 +41,7 @@ describe("InputBase Props", () => {
 			"endAdornment",
 			"metadata",
 			"autoComplete",
+			"timeoutDelay",
 		];
 
 		const ruleNames = ["input", "errorText"];


### PR DESCRIPTION
Add configurable timeoutDelay attribute that delay update of
editstate object that triggers a call when modified.

[AB#57779](https://dev.azure.com/orckestra001/da965986-c85b-43be-9915-219568b000e5/_workitems/edit/57779)