### PR TITLE
Fix SectionExpansionPanel css Position

### DIFF
--- a/src/components/MaterialUI/Surfaces/SectionExpansionPanel.js
+++ b/src/components/MaterialUI/Surfaces/SectionExpansionPanel.js
@@ -40,6 +40,7 @@ const useStyles = makeStyles(theme => ({
 	panelRoot: {
 		"&$panelExpanded": {
 			margin: "0",
+			position: "unset",
 			"&:before": {
 				opacity: "1",
 			},


### PR DESCRIPTION
Remove CSS position definition so that the popup can calculate it's z-index and position outside of the SectionExpansionPanel