### PR TITLE
Set Logout flag also for 401(Unauthorized) status code 

### DIFF
--- a/src/reducers/request.js
+++ b/src/reducers/request.js
@@ -24,7 +24,8 @@ const requestReducer = (state = initialState, action) => {
 	}
 	if (action.type.endsWith("_FAILURE")) {
 		const requestName = action.type.replace(/_FAILURE$/, "");
-		if (safeGet(action, "payload", "status") === 403) {
+		const status = safeGet(action, "payload", "status");
+		if (status === 403 || status === 401) {
 			return state.deleteIn(["actives", requestName]).set("logout", true);
 		} else {
 			return state.deleteIn(["actives", requestName]).set("error", Immutable.fromJS(action));

--- a/src/reducers/request.test.js
+++ b/src/reducers/request.test.js
@@ -125,4 +125,27 @@ describe("Request reducer", () => {
 			}),
 		);
 	});
+
+	it("clears activity flag and sets login flag when a request fails with status 401", () => {
+		const oldState = Immutable.fromJS({
+			actives: {
+				SOME_FLAG: true,
+				TEST_THIS: true,
+			},
+		});
+		const action = {
+			type: "TEST_THIS_FAILURE",
+			payload: { status: 401, message: "UnauthorizedAccessException" },
+		};
+		const newState = reducer(oldState, action);
+		expect(newState, "not to be", oldState).and(
+			"to equal",
+			Immutable.fromJS({
+				actives: {
+					SOME_FLAG: true,
+				},
+				[LOGOUT]: true,
+			}),
+		);
+	});
 });


### PR DESCRIPTION

Right now the logout flag set to true just for 403(Forbidden) status code
Search APIs can return 401(Unauthorized) status code so we need this logic also
