### PR TITLE
trimSpacesAndLeadingZeros supports negative values, returns 0 when value is 0[0+]

### DIFF
--- a/src/utils/inputHelper.js
+++ b/src/utils/inputHelper.js
@@ -1,6 +1,22 @@
 export const trimSpacesAndLeadingZeros = (value, fallback = "") => {
-	const trimmed = (value ?? "").trim().replace(/^0+/, "");
-	return trimmed === "" ? fallback : limitNumericValueLength(trimmed);
+	if (!value || isNaN(value)) {
+		return fallback;
+	}
+
+	let trimmed = value.trim();
+	const isNegative = trimmed[0] === "-";
+	if (isNegative) {
+		trimmed = trimmed.substring(1, trimmed.length);
+	}
+
+	const withoutLeadingZeros = trimmed.replace(/^0+/, "");
+	if (withoutLeadingZeros == "") {
+		return "0";
+	}
+
+	const cleanNumber = `${isNegative ? "-" : ""}${withoutLeadingZeros}`;
+
+	return limitNumericValueLength(cleanNumber);
 };
 
 export const limitNumericValueLength = (value, maximum = 9) => value.substring(0, maximum);

--- a/src/utils/inputHelper.test.js
+++ b/src/utils/inputHelper.test.js
@@ -5,12 +5,24 @@ describe("Numeric Input Helper", () => {
 		expect(trimSpacesAndLeadingZeros, "when called with", ["  00013 "], "to equal", "13");
 	});
 
-	it("trimSpacesAndLeadingZeros trims spaces and leading zeros returning fallback value", () => {
-		expect(trimSpacesAndLeadingZeros, "when called with", [" 000  ", "def"], "to equal", "def");
+	it("trimSpacesAndLeadingZeros trims spaces and leading zeros returning 0 when 000 value", () => {
+		expect(trimSpacesAndLeadingZeros, "when called with", [" 000  ", "def"], "to equal", "0");
+	});
+
+	it("trimSpacesAndLeadingZeros trims spaces and leading zeros returning fallback when empty string value", () => {
+		expect(trimSpacesAndLeadingZeros, "when called with", ["", "def"], "to equal", "def");
+	});
+
+	it("trimSpacesAndLeadingZeros trims spaces and leading zeros returning 0 when 0 value", () => {
+		expect(trimSpacesAndLeadingZeros, "when called with", [" 0 ", "def"], "to equal", "0");
 	});
 
 	it("trimSpacesAndLeadingZeros should work on floating values", () => {
 		expect(trimSpacesAndLeadingZeros, "when called with", ["042.2", "def"], "to equal", "42.2");
+	});
+
+	it("trimSpacesAndLeadingZeros should work on negative values", () => {
+		expect(trimSpacesAndLeadingZeros, "when called with", ["-0012.2", "def"], "to equal", "-12.2");
 	});
 
 	it("trimSpacesAndLeadingZeros returns fallback on null value", () => {
@@ -19,6 +31,10 @@ describe("Numeric Input Helper", () => {
 
 	it("trimSpacesAndLeadingZeros returns fallback on undefined value", () => {
 		expect(trimSpacesAndLeadingZeros, "when called with", [undefined, "def"], "to equal", "def");
+	});
+
+	it("trimSpacesAndLeadingZeros returns fallback when value is not a number", () => {
+		expect(trimSpacesAndLeadingZeros, "when called with", ["hello", "def"], "to equal", "def");
 	});
 
 	it("limitNumericValueLength trims extra characters", () => {


### PR DESCRIPTION
trimSpacesAndLeadingZeros supports negative values, returns 0 when value is 0[0+]

Bug: [AB#78844](https://dev.azure.com/orckestra001/da965986-c85b-43be-9915-219568b000e5/_workitems/edit/78844)