### PR TITLE
The default "Next" button in the Stepper fails when clicking on it

### DIFF
--- a/src/components/MaterialUI/DataDisplay/PredefinedElements/StepperModal.js
+++ b/src/components/MaterialUI/DataDisplay/PredefinedElements/StepperModal.js
@@ -180,7 +180,13 @@ const StepperModal = ({
 								</Button>
 							))
 						) : (
-							<Button variant="contained" color="primary" disabled={nextDisabled} onClick={nextClick} disableElevation>
+							<Button
+								variant="contained"
+								color="primary"
+								disabled={nextDisabled}
+								onClick={() => nextClick()}
+								disableElevation
+							>
 								<FormattedMessage {...sharedMessages.next} />
 							</Button>
 						))}


### PR DESCRIPTION
The default "Next" button in the Stepper fails when clicking on it

Story: [AB#80179](https://dev.azure.com/orckestra001/da965986-c85b-43be-9915-219568b000e5/_workitems/edit/80179)