### PR TITLE
Prevent DropDownMenu click propagation when releasing mouse button outside the menu 

### DIFF
--- a/src/components/MaterialUI/Navigation/DropDownMenu.js
+++ b/src/components/MaterialUI/Navigation/DropDownMenu.js
@@ -47,6 +47,13 @@ const DropDownMenu = ({ payload, menuItems, children, dropDownMenuProps = new Dr
 		setAnchorEl(null);
 	};
 
+	// Even though we do nothing, we need to avoid mouse event propagation when the mouse
+	// button is released after hovering out the menu
+	const onMainMenuClick = event => {
+		event.preventDefault();
+		event.stopPropagation();
+	};
+
 	const onMenuItemClick = (action, itemContext) => event => {
 		onClose(event);
 		action(payload, itemContext);
@@ -76,6 +83,7 @@ const DropDownMenu = ({ payload, menuItems, children, dropDownMenuProps = new Dr
 				classes={{ paper: classes.menu }}
 				id="scope-menu"
 				open={isOpened}
+				onClick={onMainMenuClick}
 				onClose={onClose}
 				autoFocus={autoFocus}
 				anchorEl={anchorEl}

--- a/src/components/MaterialUI/Navigation/DropDownMenu.test.js
+++ b/src/components/MaterialUI/Navigation/DropDownMenu.test.js
@@ -8,6 +8,7 @@ import Icon from "../DataDisplay/Icon";
 import DropDownMenu from "./DropDownMenu";
 import { ignoreConsoleError } from "../../../utils/testUtils";
 import { TestWrapper, createMuiTheme } from "./../../../utils/testUtils";
+import Menu from "@material-ui/core/Menu";
 
 describe("DropDownMenu", () => {
 	let store, menuItems, container;
@@ -91,5 +92,28 @@ describe("DropDownMenu", () => {
 
 		expect(menuItems[0].action, "to have calls satisfying", [{ args: [payload, "aContext"] }]);
 		expect(menuItems[1].action, "to have calls satisfying", [{ args: [payload, "myContext"] }]);
+	});
+
+	it("should handle onClick event on the menu", () => {
+		const payload = "payload";
+
+		const component = (
+			<Provider store={store}>
+				<DropDownMenu payload={payload} menuItems={menuItems} />
+			</Provider>
+		);
+
+		const mountedComponent = mount(component);
+
+		const event = {
+			preventDefault: sinon.spy().named("preventDefault"),
+			stopPropagation: sinon.spy().named("stopPropagation"),
+		};
+
+		const dropDownMenu = mountedComponent.find(Menu).at(0);
+		dropDownMenu.invoke("onClick")(event);
+
+		expect(event.preventDefault, "was called");
+		expect(event.stopPropagation, "was called");
 	});
 });


### PR DESCRIPTION
Prevent DropDownMenu click propagation when releasing mouse button outside the menu

AB#85222